### PR TITLE
Implement leader election.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ bin/contour-plus: main.go cmd/root.go controllers/ingressroute_controller.go
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./controllers/..."
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=contour-plus paths="./..."
 
 # Run go vet against code
 vet:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: contour-plus
 rules:
 - apiGroups:
   - contour.heptio.com
@@ -57,3 +57,23 @@ rules:
   - services/status
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: contour-plus-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: contour-plus
 subjects:
 - kind: ServiceAccount
   name: default

--- a/controllers/ingressroute_controller.go
+++ b/controllers/ingressroute_controller.go
@@ -42,13 +42,14 @@ type IngressRouteReconciler struct {
 	CreateCertificate bool
 }
 
-// Reconcile creates/updates CRDs from given IngressRoute
 // +kubebuilder:rbac:groups=contour.heptio.com,resources=ingressroutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=contour.heptio.com,resources=ingressroutes/status,verbs=get
 // +kubebuilder:rbac:groups=externaldns.k8s.io,resources=dnsendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=certmanager.k8s.io,resources=certificate,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;watch
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get
+
+// Reconcile creates/updates CRDs from given IngressRoute
 func (r *IngressRouteReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("ingressroute", req.NamespacedName)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,9 +35,27 @@ How it works
 contour-plus should be deployed with Deployment.  It monitors events for [IngressRoute][] and
 creates / updates / deletes [DNSEndpoint][] and/or [Certificate][].
 
+### Leader election
+
+contour-plus will do leader election if `POD_NAMESPACE` environment variable is set.
+The environment variable should be given in deployment YAML as follows:
+
+```yaml
+    containers:
+    - name: contour-plus
+      image: quay.io/cybozu/contour-plus:latest
+      env:
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+```
+
+The container should be deployed as a sidecar of Contour/Envoy pod.
+
 ### Supported annotations
 
-You can specify the following annotations on IngressRoute in order to trigger CRD resources to be automatically created.
+contour-plus interprets following annotations for IngressRoute.
 
 - `contour-plus.cybozu.com/exclude: "true"` - If this annotation is annotated, contour-plus does not generate CRD resources from the IngressRoute.
 - `certmanager.k8s.io/issuer` - The name of an  [Issuer][] to acquire the certificate required for this Ingressroute from. The Issuer must be in the same namespace as the IngressRoute.


### PR DESCRIPTION
contour-plus elects a leader when POD_NAMESPACE environment variable
is set.  It uses a ConfigMap named "contour-plus-leader" in that
namespace for leader election.