### PR TITLE
Change flag options and metrics address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,11 @@ jobs:
       TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
-      - run: mkdir -p ${TEST_RESULTS}
-      - run:
-          name: Setup kubebuilder
-          command: |
-            os=$(go env GOOS)
-            arch=$(go env GOARCH)
-            kubebuilder=2.0.0-alpha.2
-            curl -sL https://go.kubebuilder.io/dl/${kubebuilder}/${os}/${arch} | tar -xz -C /tmp/
-            mv /tmp/kubebuilder_${kubebuilder}_${os}_${arch} /usr/local/kubebuilder
-            curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/kustomize/${os}/${arch}
-            chmod a+x /usr/local/kubebuilder/bin/kustomize
-      - run: go install -mod=vendor github.com/jstemmer/go-junit-report
+      - run: make SUDO="" setup
       - run:
           name: Run tests
           command: |
+            mkdir -p ${TEST_RESULTS}
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
             make test | tee ${TEST_RESULTS}/go-test.out
       - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin/contour-plus
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ GO111MODULE = on
 GOFLAGS     = -mod=vendor
 export GO111MODULE GOFLAGS
 
+GOOS = $(shell go env GOOS)
+GOARCH = $(shell go env GOARCH)
+SUDO = sudo
+KUBEBUILDER_VERSION = 2.0.0-alpha.2
+
 all: bin/contour-plus
 
 # Run tests
@@ -54,5 +59,12 @@ endif
 
 clean:
 	rm -f bin/contour-plus $(CONTROLLER_GEN)
+
+setup:
+	curl -sL https://go.kubebuilder.io/dl/$(KUBEBUILDER_VERSION)/$(GOOS)/$(GOARCH) | tar -xz -C /tmp/
+	$(SUDO) mv /tmp/kubebuilder_$(KUBEBUILDER_VERSION)_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
+	$(SUDO) curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/kustomize/$(GOOS)/$(GOARCH)
+	$(SUDO) chmod a+x /usr/local/kubebuilder/bin/kustomize
+	go install github.com/jstemmer/go-junit-report
 
 .PHONY: all test manifests vet generate docker-build docker-push

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 
 	fs := rootCmd.Flags()
-	fs.String("metrics-addr", ":8080", "Bind address for the metrics endpoint")
+	fs.String("metrics-addr", ":8180", "Bind address for the metrics endpoint")
 	fs.StringSlice("crds", []string{dnsEndpointKind, certmanagerv1alpha1.CertificateKind}, "List of CRD names to be created")
 	fs.String("name-prefix", "", "Prefix of CRD names to be created")
 	fs.String("service-name", "", "NamespacedName of the Contour LoadBalancer Service")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,9 +78,6 @@ func init() {
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}
-	if err := cobra.MarkFlagRequired(fs, "service-name"); err != nil {
-		panic(err)
-	}
 	viper.SetEnvPrefix("cp")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@ If both is specified, command-line flags take precedence.
 
 | Flag                  | Envvar                   | Default                   | Description                                                   |
 | --------------------- | ------------------------ | ------------------------- | ------------------------------------------------------------- |
-| `metrics-addr`        | `CP_METRICS_ADDR`        | :8080                     | Bind address for the metrics endpoint                         |
+| `metrics-addr`        | `CP_METRICS_ADDR`        | :8180                     | Bind address for the metrics endpoint                         |
 | `crds`                | `CP_CRDS`                | `DNSEndpoint,Certificate` | Comma-separated list of CRDs to be created                    |
 | `name-prefix`         | `CP_NAME_PREFIX`         | ""                        | Prefix of CRD names to be created                             |
 | `service-name`        | `CP_SERVICE_NAME`        | ""                        | NamespacedName of the Contour LoadBalancer Service (required) |


### PR DESCRIPTION
This PR contains two commits:

1. Do not mark `--service-name` as required.
    Marking so prohibits use of `CP_SERVICE_NAME` environment variable.
2. Change the default metrics address from :8080 to :8180.
    :8080 conflicts with Envoy.