### PR TITLE
Fix data race in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: vet manifests
 	test -z "$$(nilerr ./... 2>&1 | tee /dev/stderr)"
 	test -z "$$(custom-checker -restrictpkg.packages=html/template,log $$(go list -tags='$(GOTAGS)' ./... | grep -v /vendor/ ) 2>&1 | tee /dev/stderr)"
 	ineffassign .
-	go test -v -count 1 ./controllers/... -coverprofile cover.out
+	go test -race -v -count 1 ./controllers/... -coverprofile cover.out
 
 # Build contour-plus binary
 bin/contour-plus: main.go cmd/root.go controllers/ingressroute_controller.go controllers/httpproxy_controller.go

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -118,7 +118,8 @@ func startTestManager(mgr manager.Manager) (stop func()) {
 }
 
 func setupManager() (*runtime.Scheme, manager.Manager) {
-	scm := scheme.Scheme
+	scm := runtime.NewScheme()
+	scheme.AddToScheme(scm)
 	Expect(SetupScheme(scm)).ShouldNot(HaveOccurred())
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scm})
 	Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
There was a data race in test code on a global variable `scheme.Scheme`.