### PR TITLE
Update contour dependency to 1.11.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,7 @@ jobs:
     steps:
       - checkout
       - run: make SUDO="" setup
-      - run:
-          name: Run tests
-          command: |
-            mkdir -p ${TEST_RESULTS}
-            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            make test | tee ${TEST_RESULTS}/go-test.out
-      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: /tmp/test-results
-          destination: raw-test-output
-      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-          path: /tmp/test-results
+      - run: make test
       - run: make
       - persist_to_workspace:
           root: /work/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/cybozu/golang:1.13-bionic
+      - image: quay.io/cybozu/golang:1.15-focal
     working_directory: /work
     environment:
       TEST_RESULTS: /tmp/test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-02-01
+
+### Changed
+
+- Update contour to 1.11.0 (#53)
+- Update controller-runtime to 0.7.2 (#53)
+
 ## [0.5.2] - 2020-10-20
 
 ### Changed
@@ -12,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update contour to 1.9.0 (#48).
 - Use cert-manager v1 API Endpoint (#48).
 - Remove compile dependency on cert-manager and external-dns (#48).
-- Stop using vendoring (#50).
+- Stop vendoring dependencies (#50).
 
 ## [0.5.1] - 2020-10-02
 
@@ -140,7 +147,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - for [ExternalDNS][] v0.5.14
     - for [cert-manager][] v0.8.0
 
-[Unreleased]: https://github.com/cybozu-go/contour-plus/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/contour-plus/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/cybozu-go/contour-plus/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/cybozu-go/contour-plus/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/cybozu-go/contour-plus/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/cybozu-go/contour-plus/compare/v0.4.3...v0.5.0

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ setup: custom-checker staticcheck nilerr ineffassign
 	rm -rf /tmp/kubebuilder_*
 	curl -o bin/kustomize -sfL https://go.kubebuilder.io/kustomize/$(GOOS)/$(GOARCH)
 	chmod a+x bin/kustomize
-	go install github.com/jstemmer/go-junit-report
 
 .PHONY: mod
 mod:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Documentation
 [docs](docs/) directory contains documents about designs and specifications.
 
 [releases]: https://github.com/cybozu-go/contour-plus/releases
-[godoc]: https://godoc.org/github.com/cybozu-go/contour-plus
+[godoc]: https://pkg.go.dev/github.com/cybozu-go/contour-plus
 [Contour]: https://github.com/projectcontour/contour
 [ExternalDNS]: https://github.com/kubernetes-sigs/external-dns
 [cert-manager]: https://github.com/jetstack/cert-manager
-[HTTPProxy]: https://github.com/projectcontour/contour/blob/master/site/docs/master/httpproxy.md
+[HTTPProxy]: https://projectcontour.io/docs/v1.11.0/config/api/#projectcontour.io/v1.HTTPProxy
 [DNSEndpoint]: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/contributing/crd-source.md
 [Certificate]: http://docs.cert-manager.io/en/latest/reference/certificates.html
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ Bump version
 ------------
 
 1. Determine a new version number.  Let it write `$VERSION` as `VERSION=x.y.z`.
-2. Checkout `master` branch.
+2. Checkout `main` branch.
 3. Make a branch to release, for example by `git neco dev "$VERSION"`
 4. Edit `CHANGELOG.md` for the new version ([example][]).
 5. Edit `README.md` for the new version ([readme-example][]) if needed.
@@ -45,7 +45,7 @@ Bump version
     $ git neco review
     ```
 7. Merge this branch.
-8. Checkout `master` branch.
+8. Checkout `main` branch.
 9. Add a git tag, then push it.
 
     ```console

--- a/config/crd/third/certmanager.yml
+++ b/config/crd/third/certmanager.yml
@@ -1,4 +1,4 @@
-# Copyright YEAR The Jetstack cert-manager contributors.
+# Copyright  The Jetstack cert-manager contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -920,6 +920,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -1328,6 +1332,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -1735,6 +1743,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -2144,6 +2156,10 @@ spec:
                 items:
                   type: string
                 type: array
+              encodeUsagesInRequest:
+                description: EncodeUsagesInRequest controls whether key usages should
+                  be present in the CertificateRequest
+                type: boolean
               ipAddresses:
                 description: IPAddresses is a list of IP address subjectAltNames to
                   be set on the Certificate.
@@ -8602,6 +8618,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -10574,6 +10597,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -12546,6 +12576,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -14520,6 +14557,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -16530,6 +16574,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -18501,6 +18552,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -20472,6 +20530,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -22445,6 +22510,13 @@ spec:
                       notification emails. This field may be updated after the account
                       is initially registered.
                     type: string
+                  enableDurationFeature:
+                    description: Enables requesting a Not After date on certificates
+                      that matches the duration of the certificate. This is not supported
+                      by all ACME servers like Let's Encrypt. If set to true when
+                      the ACME server does not support it it will create an error
+                      on the Order. Defaults to false.
+                    type: boolean
                   externalAccountBinding:
                     description: ExternalAccountBinding is a reference to a CA external
                       account of the ACME server. If set, upon registration cert-manager
@@ -24439,9 +24511,9 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               csr:
                 description: Certificate signing request bytes in DER encoding. This
@@ -24453,6 +24525,18 @@ spec:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24477,7 +24561,6 @@ spec:
                 type: object
             required:
             - csr
-            - dnsNames
             - issuerRef
             type: object
           status:
@@ -24647,9 +24730,9 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               csr:
                 description: Certificate signing request bytes in DER encoding. This
@@ -24661,6 +24744,18 @@ spec:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24685,7 +24780,6 @@ spec:
                 type: object
             required:
             - csr
-            - dnsNames
             - issuerRef
             type: object
           status:
@@ -24855,14 +24949,26 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               dnsNames:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -24892,7 +24998,6 @@ spec:
                 format: byte
                 type: string
             required:
-            - dnsNames
             - issuerRef
             - request
             type: object
@@ -25064,14 +25169,26 @@ spec:
             properties:
               commonName:
                 description: CommonName is the common name as specified on the DER
-                  encoded CSR. If specified, this value must also be present in `dnsNames`.
-                  This field must match the corresponding field on the DER encoded
-                  CSR.
+                  encoded CSR. If specified, this value must also be present in `dnsNames`
+                  or `ipAddresses`. This field must match the corresponding field
+                  on the DER encoded CSR.
                 type: string
               dnsNames:
                 description: DNSNames is a list of DNS names that should be included
                   as part of the Order validation process. This field must match the
                   corresponding field on the DER encoded CSR.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Duration is the duration for the not after date for the
+                  requested certificate. this is set on order creation as pe the ACME
+                  spec.
+                type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses that should be
+                  included as part of the Order validation process. This field must
+                  match the corresponding field on the DER encoded CSR.
                 items:
                   type: string
                 type: array
@@ -25101,7 +25218,6 @@ spec:
                 format: byte
                 type: string
             required:
-            - dnsNames
             - issuerRef
             - request
             type: object

--- a/config/crd/third/httpproxy.yml
+++ b/config/crd/third/httpproxy.yml
@@ -49,9 +49,9 @@ spec:
                 - h2c
                 type: string
               protocolVersion:
-                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v3 Envoy API, this is currently fixed at "v3". However, other protocol options will be available in future.
                 enum:
-                - v2
+                - v3
                 type: string
               services:
                 description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.
@@ -148,20 +148,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -174,7 +174,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -979,20 +979,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1005,7 +1005,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1113,7 +1113,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation. See design/tls-certificate-delegation.md for details.
+        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specification. See design/tls-certificate-delegation.md for details.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1189,20 +1189,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1215,7 +1215,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -109,14 +109,14 @@ var _ = Describe("Test contour-plus", func() {
 })
 
 func startTestManager(mgr manager.Manager) (stop func()) {
-	ch := make(chan struct{})
 	waitCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	stop = func() {
-		close(ch)
+		cancel()
 		<-waitCh
 	}
 	go func() {
-		err := mgr.Start(ch)
+		err := mgr.Start(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -86,15 +86,15 @@ var _ = BeforeSuite(func() {
 			LoadBalancerIP: dummyLoadBalancerIP,
 			Type:           corev1.ServiceTypeLoadBalancer,
 		},
-		Status: corev1.ServiceStatus{
-			LoadBalancer: corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{{
-					IP: dummyLoadBalancerIP,
-				}},
-			},
-		},
 	}
 	Expect(k8sClient.Create(context.Background(), svc)).ShouldNot(HaveOccurred())
+	svc.Status = corev1.ServiceStatus{
+		LoadBalancer: corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{{
+				IP: dummyLoadBalancerIP,
+			}},
+		},
+	}
 	Expect(k8sClient.Status().Update(context.Background(), svc)).ShouldNot(HaveOccurred())
 }, 60)
 

--- a/go.mod
+++ b/go.mod
@@ -2,27 +2,18 @@ module github.com/cybozu-go/contour-plus
 
 go 1.13
 
-replace launchpad.net/gocheck => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
-
 require (
-	github.com/go-logr/logr v0.1.0
-	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
-	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
-	github.com/onsi/ginkgo v1.14.1
-	github.com/onsi/gomega v1.10.2
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/projectcontour/contour v1.9.0
-	github.com/prometheus/client_golang v1.7.1 // indirect
-	github.com/spf13/cobra v1.0.0
-	github.com/spf13/viper v1.4.0
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.2
+	github.com/onsi/gomega v1.10.4
+	github.com/projectcontour/contour v1.11.0
+	github.com/spf13/cobra v1.1.1
+	github.com/spf13/viper v1.7.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/appengine v1.6.5 // indirect
-	k8s.io/api v0.18.9
-	k8s.io/apimachinery v0.18.9
-	k8s.io/client-go v0.18.9
+	k8s.io/api v0.19.7
+	k8s.io/apimachinery v0.19.7
+	k8s.io/client-go v0.19.7
 	k8s.io/klog v1.0.0
-	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
-	sigs.k8s.io/controller-runtime v0.6.3
+	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
+	sigs.k8s.io/controller-runtime v0.7.2
 )

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package main
-
-import (
-	_ "github.com/jstemmer/go-junit-report"
-)


### PR DESCRIPTION
This PR contains necessary fixes to update Contour dependency to 1.11.0.

Most notably, controller-runtime is upgraded from 0.6.3 to 0.7.2 to align with k8s.io/client-go@v0.19.
However, kubebuilder is unchanged because kubebuilder v3 is still in its alpha stage.