### PR TITLE
Migrate to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - 'v*'
 jobs:
   image:
-    name: Push image to quay.io
+    name: Push container image
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -17,16 +17,20 @@ jobs:
       - run: make lint
       - run: make test
       - run: make docker-build
-      - name: Log in quay.io
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
-      - name: Push versioned image to quay.io
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push versioned image to ghcr.io
         run: |
           TAG=${GITHUB_REF#refs/tags/v}
-          docker tag quay.io/cybozu/contour-plus:latest quay.io/cybozu/contour-plus:$TAG
-          docker push quay.io/cybozu/contour-plus:$TAG
-      - name: Push latest image to quay.io
+          docker tag ghcr.io/cybozu-go/contour-plus:latest ghcr.io/cybozu-go/contour-plus:$TAG
+          docker push ghcr.io/cybozu-go/contour-plus:$TAG
+      - name: Push latest image to ghcr.io
         if: ${{ !contains(github.ref, '-') }}
-        run: docker push quay.io/cybozu/contour-plus:latest
+        run: docker push ghcr.io/cybozu-go/contour-plus:latest
   release:
     name: Release on GitHub
     needs: image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/cybozu-go/contour-plus"
 
 COPY bin/contour-plus /contour-plus
 COPY LICENSE          /LICENSE

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Documentation
 Docker images
 -------------
 
-Docker images are available on [Quay.io](https://quay.io/repository/cybozu/contour-plus)
+Docker images are available on [ghcr.io](https://github.com/cybozu-go/contour-plus/pkgs/container/contour-plus)


### PR DESCRIPTION
This PR migrates the repository to use ghcr.io.

A container-registry is prepared beforehand with a temporary image tagged `dev`.
https://github.com/cybozu-go/contour-plus/pkgs/container/contour-plus

ref. https://github.com/cybozu-go/coil/blob/main/.github/workflows/release.yaml

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>