### PR TITLE
Fix image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GH := $(BIN_DIR)/gh
 YQ := $(BIN_DIR)/yq
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/cybozu/contour-plus:latest
+IMG ?= ghcr.io/cybozu-go/contour-plus:latest
 
 # Set the shell used to bash for better error handling.
 SHELL = /bin/bash


### PR DESCRIPTION
CI failed to create a release because it depends on the correct image name:
https://github.com/cybozu-go/contour-plus/actions/runs/7485902670/job/20375202489

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>