### PR TITLE
add support for specifying revisionHistoryLimit for the generated Certificate

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ func init() {
 	fs.String("service-name", "", "NamespacedName of the Contour LoadBalancer Service")
 	fs.String("default-issuer-name", "", "Issuer name used by default")
 	fs.String("default-issuer-kind", controllers.ClusterIssuerKind, "Issuer kind used by default")
+	fs.Uint("csr-revision-limit", 0, "Maximum number of CertificateRequest revisions to keep")
 	fs.String("ingress-class-name", "", "Ingress class name that watched by Contour Plus. If not specified, then all classes are watched")
 	fs.Bool("leader-election", true, "Enable/disable leader election")
 	if err := viper.BindPFlags(fs); err != nil {
@@ -65,6 +66,7 @@ In addition to flags, the following environment variables are read:
 	CP_SERVICE_NAME          NamespacedName of the Contour LoadBalancer Service
 	CP_DEFAULT_ISSUER_NAME   Issuer name used by default
 	CP_DEFAULT_ISSUER_KIND   Issuer kind used by default
+	CP_CSR_REVISION_LIMIT    Maximum number of CertificateRequest revisions to keep
 	CP_LEADER_ELECTION       Disable leader election if set to "false"
 	CP_INGRESS_CLASS_NAME    Ingress class name that watched by Contour Plus. If not specified, then all classes are watched`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,6 +66,8 @@ func run() error {
 
 	opts.IngressClassName = viper.GetString("ingress-class-name")
 
+	opts.CSRRevisionLimit = viper.GetUint("csr-revision-limit")
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -17,6 +17,7 @@ type ReconcilerOptions struct {
 	Prefix            string
 	DefaultIssuerName string
 	DefaultIssuerKind string
+	CSRRevisionLimit  uint
 	CreateDNSEndpoint bool
 	CreateCertificate bool
 	IngressClassName  string
@@ -40,6 +41,7 @@ func SetupReconciler(mgr manager.Manager, scheme *runtime.Scheme, opts Reconcile
 		Prefix:            opts.Prefix,
 		DefaultIssuerName: opts.DefaultIssuerName,
 		DefaultIssuerKind: opts.DefaultIssuerKind,
+		CSRRevisionLimit:  opts.CSRRevisionLimit,
 		CreateDNSEndpoint: opts.CreateDNSEndpoint,
 		CreateCertificate: opts.CreateCertificate,
 		IngressClassName:  opts.IngressClassName,


### PR DESCRIPTION
Currently, contour-plus creates Certificates without setting `.spec.revisionHistoryLimit`. As a result, the number of CertificateRequests is unbounded and will keep increasing as existing Certificates are renewed or updated. In a long-lived cluster with a lot of HTTPProxies relying on contour-plus, this will lead to a large amount of unnecessary CertificateRequests being kept around.

This PR adds support for specifying the upper-bound for the number of CertificateRequests kept per Certificate, allowing cert-manager to perform garbage-collection on older CertificateRequests and keeping things tidy.