### PR TITLE
Add support for specifying revision history limit via annotation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,7 @@ If both is specified, command-line flags take precedence.
 | `default-issuer-kind` | `CP_DEFAULT_ISSUER_KIND` | `ClusterIssuer`           | Issuer kind used by default                        |
 | `default-delegated-domain` | `CP_DEFAULT_DELEGATED_DOMAIN` | ""            | Domain to which DNS-01 validation is delegated to   |
 | `allow-custom-delegations` | `CP_ALLOW_CUSTOM_DELEGATIONS` | `false`       | Allow users to specify a custom delegated domain |
+| `csr-revision-limit`  | `CP_CSR_REVISION_LIMIT`  | 0                         | Maximum number of CertificateRequests to be kept for a Certificate. By default, all CertificateRequests are kept             |
 | `leader-election`     | `CP_LEADER_ELECTION`     | `true`                    | Enable / disable leader election                   |
 | `ingress-class-name`  | `CP_INGRESS_CLASS_NAME`  | ""                        | Ingress class name that watched by Contour Plus. If not specified, then all classes are watched    |
 
@@ -125,10 +126,13 @@ contour-plus interprets following annotations for HTTPProxy.
 - `contour-plus.cybozu.com/exclude: "true"` - With this, contour-plus ignores this HTTPProxy.
 - `cert-manager.io/issuer` - The name of an  [Issuer][] to acquire the certificate required for this HTTPProxy from. The Issuer must be in the same namespace as the HTTPProxy.
 - `cert-manager.io/cluster-issuer` - The name of a [ClusterIssuer][Issuer] to acquire the certificate required for this ingress from. It does not matter which namespace your Ingress resides, as ClusterIssuers are non-namespaced resources.
+- `cert-manager.io/revision-history-limit` - The maximum number of CertificateRequests to keep for a given Certificate.
 - `kubernetes.io/tls-acme: "true"` - With this, contour-plus generates Certificate automatically from HTTPProxy.
 - `contour-plus.cybozu.com/delegated-domain: "acme.example.com"` - With this, contour-plus generates a [DNSEndpoint][] to create a CNAME record pointing to the delegation domain for use when performing DNS-01 DCV during the Certificate creation.
 
 If both of `cert-manager.io/issuer` and `cert-manager.io/cluster-issuer` exist, `cluster-issuer` takes precedence.
+
+If `cert-manager.io/revision-history-limit` is present, it takes precedence over the value globally specified via the `--csr-revision-limit` command-line flag.
 
 [Contour]: https://github.com/heptio/contour
 [HTTPProxy]: https://github.com/projectcontour/contour/blob/master/site/docs/master/httpproxy.md


### PR DESCRIPTION
The previous change introduced in #104 lacked documentation, and I've added support for specifying `.spec.revisionHistoryLimit` via the `cert-manager.io/revision-history-limit` annotation, aligning with expectations users familiar with cert-manager would have.