### PR TITLE
Add support for using delegated domains for DNS-01

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ func init() {
 	fs.String("service-name", "", "NamespacedName of the Contour LoadBalancer Service")
 	fs.String("default-issuer-name", "", "Issuer name used by default")
 	fs.String("default-issuer-kind", controllers.ClusterIssuerKind, "Issuer kind used by default")
+	fs.String("default-delegated-domain", "", "Delegated domain used by default")
+	fs.Bool("allow-custom-delegations", false, "Allow custom delegated domains via annotations")
 	fs.Uint("csr-revision-limit", 0, "Maximum number of CertificateRequest revisions to keep")
 	fs.String("ingress-class-name", "", "Ingress class name that watched by Contour Plus. If not specified, then all classes are watched")
 	fs.Bool("leader-election", true, "Enable/disable leader election")
@@ -60,15 +62,17 @@ var rootCmd = &cobra.Command{
 	
 In addition to flags, the following environment variables are read:
 
-	CP_METRICS_ADDR          Bind address for the metrics endpoint
-	CP_CRDS                  Comma-separated list of CRD names
-	CP_NAME_PREFIX           Prefix of CRD names to be created
-	CP_SERVICE_NAME          NamespacedName of the Contour LoadBalancer Service
-	CP_DEFAULT_ISSUER_NAME   Issuer name used by default
-	CP_DEFAULT_ISSUER_KIND   Issuer kind used by default
-	CP_CSR_REVISION_LIMIT    Maximum number of CertificateRequest revisions to keep
-	CP_LEADER_ELECTION       Disable leader election if set to "false"
-	CP_INGRESS_CLASS_NAME    Ingress class name that watched by Contour Plus. If not specified, then all classes are watched`,
+	CP_METRICS_ADDR             Bind address for the metrics endpoint
+	CP_CRDS                     Comma-separated list of CRD names
+	CP_NAME_PREFIX              Prefix of CRD names to be created
+	CP_SERVICE_NAME             NamespacedName of the Contour LoadBalancer Service
+	CP_DEFAULT_ISSUER_NAME      Issuer name used by default
+	CP_DEFAULT_ISSUER_KIND      Issuer kind used by default
+	CP_DEFAULT_DELEGATED_DOMAIN Delegation domain used by default
+	CP_ALLOW_CUSTOM_DELEGATIONS Allow custom delegated domains via annotations
+	CP_CSR_REVISION_LIMIT       Maximum number of CertificateRequest revisions to keep
+	CP_LEADER_ELECTION          Disable leader election if set to "false"
+	CP_INGRESS_CLASS_NAME       Ingress class name that watched by Contour Plus. If not specified, then all classes are watched`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		return run()

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -13,14 +13,16 @@ import (
 
 // ReconcilerOptions is a set of options for reconcilers
 type ReconcilerOptions struct {
-	ServiceKey        client.ObjectKey
-	Prefix            string
-	DefaultIssuerName string
-	DefaultIssuerKind string
-	CSRRevisionLimit  uint
-	CreateDNSEndpoint bool
-	CreateCertificate bool
-	IngressClassName  string
+	ServiceKey             client.ObjectKey
+	Prefix                 string
+	DefaultIssuerName      string
+	DefaultIssuerKind      string
+	DefaultDelegatedDomain string
+	AllowCustomDelegations bool
+	CSRRevisionLimit       uint
+	CreateDNSEndpoint      bool
+	CreateCertificate      bool
+	IngressClassName       string
 }
 
 // SetupScheme initializes a schema
@@ -34,17 +36,19 @@ func SetupScheme(scm *runtime.Scheme) {
 // SetupReconciler initializes reconcilers
 func SetupReconciler(mgr manager.Manager, scheme *runtime.Scheme, opts ReconcilerOptions) error {
 	httpProxyReconciler := &HTTPProxyReconciler{
-		Client:            mgr.GetClient(),
-		Log:               ctrl.Log.WithName("controllers").WithName("HTTPProxy"),
-		Scheme:            scheme,
-		ServiceKey:        opts.ServiceKey,
-		Prefix:            opts.Prefix,
-		DefaultIssuerName: opts.DefaultIssuerName,
-		DefaultIssuerKind: opts.DefaultIssuerKind,
-		CSRRevisionLimit:  opts.CSRRevisionLimit,
-		CreateDNSEndpoint: opts.CreateDNSEndpoint,
-		CreateCertificate: opts.CreateCertificate,
-		IngressClassName:  opts.IngressClassName,
+		Client:                 mgr.GetClient(),
+		Log:                    ctrl.Log.WithName("controllers").WithName("HTTPProxy"),
+		Scheme:                 scheme,
+		ServiceKey:             opts.ServiceKey,
+		Prefix:                 opts.Prefix,
+		DefaultIssuerName:      opts.DefaultIssuerName,
+		DefaultIssuerKind:      opts.DefaultIssuerKind,
+		DefaultDelegatedDomain: opts.DefaultDelegatedDomain,
+		AllowCustomDelegations: opts.AllowCustomDelegations,
+		CSRRevisionLimit:       opts.CSRRevisionLimit,
+		CreateDNSEndpoint:      opts.CreateDNSEndpoint,
+		CreateCertificate:      opts.CreateCertificate,
+		IngressClassName:       opts.IngressClassName,
 	}
 	err := httpProxyReconciler.SetupWithManager(mgr)
 	if err != nil {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,7 +126,7 @@ contour-plus interprets following annotations for HTTPProxy.
 - `cert-manager.io/issuer` - The name of an  [Issuer][] to acquire the certificate required for this HTTPProxy from. The Issuer must be in the same namespace as the HTTPProxy.
 - `cert-manager.io/cluster-issuer` - The name of a [ClusterIssuer][Issuer] to acquire the certificate required for this ingress from. It does not matter which namespace your Ingress resides, as ClusterIssuers are non-namespaced resources.
 - `kubernetes.io/tls-acme: "true"` - With this, contour-plus generates Certificate automatically from HTTPProxy.
-- `contour-plus.cybozu.com/delegated-domain: "acme.example.com"` - With this, contour-plus generates will create a CNAME record pointing to the delegation domain for use when performing DNS-01 DCV during the Certificate creation.
+- `contour-plus.cybozu.com/delegated-domain: "acme.example.com"` - With this, contour-plus generates a [DNSEndpoint][] to create a CNAME record pointing to the delegation domain for use when performing DNS-01 DCV during the Certificate creation.
 
 If both of `cert-manager.io/issuer` and `cert-manager.io/cluster-issuer` exist, `cluster-issuer` takes precedence.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,11 +19,15 @@ If both is specified, command-line flags take precedence.
 | `service-name`        | `CP_SERVICE_NAME`        | ""                        | NamespacedName of the Contour LoadBalancer Service |
 | `default-issuer-name` | `CP_DEFAULT_ISSUER_NAME` | ""                        | Issuer name used by default                        |
 | `default-issuer-kind` | `CP_DEFAULT_ISSUER_KIND` | `ClusterIssuer`           | Issuer kind used by default                        |
+| `default-delegated-domain` | `CP_DEFAULT_DELEGATED_DOMAIN` | ""            | Domain to which DNS-01 validation is delegated to   |
+| `allow-custom-delegations` | `CP_ALLOW_CUSTOM_DELEGATIONS` | `false`       | Allow users to specify a custom delegated domain |
 | `leader-election`     | `CP_LEADER_ELECTION`     | `true`                    | Enable / disable leader election                   |
 | `ingress-class-name`  | `CP_INGRESS_CLASS_NAME`  | ""                        | Ingress class name that watched by Contour Plus. If not specified, then all classes are watched    |
 
 By default, contour-plus creates [DNSEndpoint][] when `spec.virtualhost.fqdn` of an HTTPProxy is not empty,
 and creates [Certificate][] when `spec.virtualhost.tls.secretName` is not empty and not namespaced.
+
+When a delegated domain is specified, either via `default-delegated-domain` or the `contour-plus.cybozu.com/delegated-domain` annotation, contour-plus creates an additional [DNSEndpoint][] delegating DNS-01 validation to the given delegation domain. The delegation record will not be created if the DNSEndpoint for `spec.virtualhost.fqdn` cannot be created.
 
 To disable CRD creation, specify `crds` command-line flag or `CP_CRDS` environment variable.
 
@@ -122,6 +126,7 @@ contour-plus interprets following annotations for HTTPProxy.
 - `cert-manager.io/issuer` - The name of an  [Issuer][] to acquire the certificate required for this HTTPProxy from. The Issuer must be in the same namespace as the HTTPProxy.
 - `cert-manager.io/cluster-issuer` - The name of a [ClusterIssuer][Issuer] to acquire the certificate required for this ingress from. It does not matter which namespace your Ingress resides, as ClusterIssuers are non-namespaced resources.
 - `kubernetes.io/tls-acme: "true"` - With this, contour-plus generates Certificate automatically from HTTPProxy.
+- `contour-plus.cybozu.com/delegated-domain: "acme.example.com"` - With this, contour-plus generates will create a CNAME record pointing to the delegation domain for use when performing DNS-01 DCV during the Certificate creation.
 
 If both of `cert-manager.io/issuer` and `cert-manager.io/cluster-issuer` exist, `cluster-issuer` takes precedence.
 


### PR DESCRIPTION
It is not desirable for cert-manager to be able to write to the root DNS zone for the sole purpose of DNS-01 validation. As such, in some environments cert-manager is expected to write to a dedicated sub-zone that exists only for DNS-01.

This PR allows contour-plus to accomodate such environments, by writing the CNAME delegation record pointing to the delegated domain when a delegated domain is specified by the contour-plus administrators via command-line flags, or by tenants via a newly defined `contour-plus.cybozu.com/delegated-domain` annotation when permitted to do so. This way, an `Issuer` or `ClusterIssuer` that has `cnameStrategy: Follow` enabled can perform DCV without writing to the root DNS zone.