### PR TITLE
implement rate limited queue to control Certificate creation rate

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 	fs.StringSlice("propagated-labels", []string{}, "List of label keys to be propagated from HTTPProxy to generated resources")
 	fs.StringSlice("allowed-dns-namespaces", []string{}, "List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed")
 	fs.StringSlice("allowed-issuer-namespaces", []string{}, "List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed")
+	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,6 +78,10 @@ func run() error {
 
 	opts.AllowedDNSNamespaces = viper.GetStringSlice("allowed-dns-namespaces")
 	opts.AllowedIssuerNamespaces = viper.GetStringSlice("allowed-issuer-namespaces")
+	opts.CertificateApplyLimit = viper.GetFloat64("certificate-apply-limit")
+	if opts.CertificateApplyLimit < 0 {
+		return errors.New("certificate-apply-limit must be greater than or equal to 0")
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -44,7 +44,7 @@ func NewCertificateApplier(client client.Client) *CertificateApplier {
 }
 
 // ApplyWorker is Applier with Start method so that it can be used directly by manager.Manager.Add
-// Imlement ApplyWorker if the Applier requires a worker that runs in a background and start it via controller manager.
+// Implement ApplyWorker if the Applier requires a worker that runs in a background and start it via controller manager.
 type ApplyWorker[T client.Object] interface {
 	Applier[T]
 	// manager.Runnable defines signature for Start

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -1,0 +1,177 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type Applier[T client.Object] interface {
+	Apply(ctx context.Context, obj T) error
+}
+
+var _ Applier[*cmv1.Certificate] = &CertificateApplier{}
+
+// CertificateApplier implements ApplyWorker[cmv1.Certificate] without a workqueue.
+// Any objects applied with Apply method will be applied without going through a queue.
+// Start method returns error unconditionally, as no worker should be started.
+type CertificateApplier struct {
+	client client.Client
+}
+
+func (w *CertificateApplier) Apply(ctx context.Context, obj *cmv1.Certificate) error {
+	return applyCertificate(ctx, w.client, obj)
+}
+
+func NewCertificateApplier(client client.Client) *CertificateApplier {
+	return &CertificateApplier{
+		client: client,
+	}
+}
+
+type ApplyWorker[T client.Object] interface {
+	Applier[T]
+	// manager.Runnable defines signature for Start
+	manager.Runnable
+}
+
+var _ ApplyWorker[*cmv1.Certificate] = &CertificateApplyWorker{}
+
+type CertificateApplyWorker struct {
+	mu sync.Mutex
+	ReconcilerOptions
+	client client.Client
+	// internal workqueue for rate limiting Certificate changes
+	workqueue workqueue.TypedRateLimitingInterface[types.NamespacedName]
+	// manifests contains full client.Object that should be applied for the key
+	manifests map[types.NamespacedName]*cmv1.Certificate
+	// limiter is the underlying rate limiter used by the workqueue
+	limiter *rate.Limiter
+}
+
+func NewCertificateApplyWorker(client client.Client, opt ReconcilerOptions) *CertificateApplyWorker {
+	limiter := rate.NewLimiter(rate.Limit(opt.CertificateApplyLimit), max(int(math.Ceil(opt.CertificateApplyLimit)), 1))
+	global := &workqueue.TypedBucketRateLimiter[types.NamespacedName]{Limiter: limiter}
+	workqueue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		global,
+		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
+			Name: "certificate-apply",
+		},
+	)
+	return &CertificateApplyWorker{
+		ReconcilerOptions: opt,
+		client:            client,
+		workqueue:         workqueue,
+		manifests:         make(map[types.NamespacedName]*cmv1.Certificate),
+		limiter:           limiter,
+	}
+}
+
+func (w *CertificateApplyWorker) Apply(ctx context.Context, obj *cmv1.Certificate) error {
+	log := crlog.FromContext(ctx)
+	objKey := types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+	requiresQueue, err := w.RequiresQueue(ctx, objKey, obj)
+	if err != nil {
+		return err
+	}
+	if requiresQueue {
+		log.Info("cert queued for apply", "key", objKey.String())
+		w.enqueueCertificate(objKey, obj)
+		return nil
+	}
+	log.Info("cert applied without queueing", "key", objKey.String())
+	return applyCertificate(ctx, w.client, obj)
+}
+
+func (w *CertificateApplyWorker) Start(ctx context.Context) error {
+	log := crlog.FromContext(ctx)
+	go func() {
+		<-ctx.Done()
+		log.Info("context.Done received. Shutting down certificate apply worker.")
+		w.workqueue.ShutDown()
+	}()
+
+	for {
+		objKey, shutdown := w.workqueue.Get()
+		if shutdown {
+			return nil
+		}
+
+		func() {
+			defer w.workqueue.Done(objKey)
+
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			obj, ok := w.manifests[objKey]
+			if !ok {
+				log.Error(fmt.Errorf("cannot find certificate manifest for %s", objKey.String()), "cert apply failed", "key", objKey.String())
+				return
+			}
+
+			if err := applyCertificate(ctx, w.client, obj); err != nil {
+				log.Error(err, "cert apply failed", "key", objKey.String())
+				w.workqueue.AddRateLimited(objKey)
+				return
+			}
+
+			log.Info("cert applied from queue", "key", objKey.String())
+			w.workqueue.Forget(objKey)
+			delete(w.manifests, objKey)
+		}()
+	}
+}
+
+// RequiresQueue indicates whether the object should be queued or not.
+func (w *CertificateApplyWorker) RequiresQueue(ctx context.Context, key types.NamespacedName, obj *cmv1.Certificate) (bool, error) {
+	log := crlog.FromContext(ctx)
+
+	current := new(cmv1.Certificate)
+	err := w.client.Get(ctx, key, current)
+	if k8serrors.IsNotFound(err) {
+		// MUST be queued with rate limit
+		return true, nil
+	}
+	if err != nil {
+		log.Error(err, "unable to get Certificate resource")
+		return false, err
+	}
+	// MUST COMPARE specs of desired and current to see if there will be re-issuance of the Certificate
+	if equality.Semantic.DeepEqual(obj.Spec, current.Spec) {
+		// no-reissuance, safe to patch without rate limit
+		return false, nil
+	}
+	return true, nil
+}
+
+func (w *CertificateApplyWorker) enqueueCertificate(objKey types.NamespacedName, obj *cmv1.Certificate) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.manifests[objKey] = obj
+	w.workqueue.AddRateLimited(objKey)
+}
+
+// applyCertificate applies provided certificate object with provided context and apiserver client
+func applyCertificate(ctx context.Context, k8sClient client.Client, obj *cmv1.Certificate) error {
+	if err := k8sClient.Patch(ctx, obj, client.Apply, &client.PatchOptions{
+		Force:        ptr.To(true),
+		FieldManager: "contour-plus",
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -153,6 +153,9 @@ func (w *CertificateApplyWorker) RequiresQueue(ctx context.Context, key types.Na
 		return false, err
 	}
 	// MUST COMPARE specs of desired and current to see if there will be re-issuance of the Certificate
+	// can safely Ignore spec.secretTemplate changes as they are only secret metadata change and does not trigger re-issuance
+	obj.Spec.SecretTemplate = nil
+	current.Spec.SecretTemplate = nil
 	if equality.Semantic.DeepEqual(obj.Spec, current.Spec) {
 		// no-reissuance, safe to patch without rate limit
 		return false, nil

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -24,9 +24,8 @@ type Applier[T client.Object] interface {
 
 var _ Applier[*cmv1.Certificate] = &CertificateApplier{}
 
-// CertificateApplier implements ApplyWorker[cmv1.Certificate] without a workqueue.
+// CertificateApplier implements Applier[cmv1.Certificate] without a workqueue.
 // Any objects applied with Apply method will be applied without going through a queue.
-// Start method returns error unconditionally, as no worker should be started.
 type CertificateApplier struct {
 	client client.Client
 }
@@ -41,6 +40,8 @@ func NewCertificateApplier(client client.Client) *CertificateApplier {
 	}
 }
 
+// ApplyWorker is Applier with Start method so that it can be used directly by manager.Manager.Add
+// Imlement ApplyWorker if the Applier requires a worker that runs in a background and start it via controller manager.
 type ApplyWorker[T client.Object] interface {
 	Applier[T]
 	// manager.Runnable defines signature for Start
@@ -49,6 +50,7 @@ type ApplyWorker[T client.Object] interface {
 
 var _ ApplyWorker[*cmv1.Certificate] = &CertificateApplyWorker{}
 
+// CertificateApplyWorker implements Applier and ApplyWorker.
 type CertificateApplyWorker struct {
 	mu sync.Mutex
 	ReconcilerOptions

--- a/controllers/certificate_worker_test.go
+++ b/controllers/certificate_worker_test.go
@@ -1,0 +1,214 @@
+package controllers
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WrappedCertificateApplyWorker struct {
+	wrapped       *CertificateApplyWorker
+	queuedCounter atomic.Uint64
+}
+
+func (w *WrappedCertificateApplyWorker) Apply(ctx context.Context, obj *cmv1.Certificate) error {
+	objKey := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	requiresQueue, err := w.wrapped.RequiresQueue(ctx, objKey, obj)
+	if err != nil {
+		return err
+	}
+	if requiresQueue {
+		w.queuedCounter.Add(1)
+	}
+	return w.wrapped.Apply(ctx, obj)
+}
+
+func (w *WrappedCertificateApplyWorker) Start(ctx context.Context) error {
+	return w.wrapped.Start(ctx)
+}
+
+func (w *WrappedCertificateApplyWorker) GetQueuedCounter() uint64 {
+	return w.queuedCounter.Load()
+}
+
+func testCertificateApplyWorkerApply() {
+	It("should create Certificate via workqueue", func() {
+		scm, mgr := setupManager()
+
+		prefix := "test-"
+		opts := ReconcilerOptions{
+			ServiceKey:            testServiceKey,
+			Prefix:                prefix,
+			DefaultIssuerName:     "test-issuer",
+			DefaultIssuerKind:     IssuerKind,
+			CreateDNSEndpoint:     true,
+			CreateCertificate:     true,
+			CertificateApplyLimit: 1,
+		}
+		applyWorker := &WrappedCertificateApplyWorker{
+			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
+		}
+		Expect(mgr.Add(applyWorker)).ShouldNot(HaveOccurred())
+
+		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		stopMgr := startTestManager(mgr)
+		defer stopMgr()
+
+		By("creating HTTPProxy")
+		hpKey := client.ObjectKey{Name: "foo", Namespace: ns}
+		Expect(k8sClient.Create(context.Background(), newDummyHTTPProxy(hpKey))).ShouldNot(HaveOccurred())
+
+		objKey := client.ObjectKey{
+			Name:      prefix + hpKey.Name,
+			Namespace: hpKey.Namespace,
+		}
+		By("getting Certificate with prefixed name")
+		crt := certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(1)))
+
+		By("creating second HTTPProxy")
+		hpKey = client.ObjectKey{Name: "bar", Namespace: ns}
+		Expect(k8sClient.Create(context.Background(), newDummyHTTPProxy(hpKey))).ShouldNot(HaveOccurred())
+
+		objKey = client.ObjectKey{
+			Name:      prefix + hpKey.Name,
+			Namespace: hpKey.Namespace,
+		}
+		By("getting second Certificate with prefixed name")
+		crt = certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed()) // use longer timeout so that it can wait for the rate limit
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(2))) // should go through queue each create
+	})
+
+	It("should update Certificate without workqueue", func() {
+		scm, mgr := setupManager()
+
+		prefix := "test-"
+		opts := ReconcilerOptions{
+			ServiceKey:            testServiceKey,
+			Prefix:                prefix,
+			DefaultIssuerName:     "test-issuer",
+			DefaultIssuerKind:     IssuerKind,
+			CreateDNSEndpoint:     true,
+			CreateCertificate:     true,
+			CertificateApplyLimit: 1,
+		}
+		applyWorker := &WrappedCertificateApplyWorker{
+			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
+		}
+		Expect(mgr.Add(applyWorker)).ShouldNot(HaveOccurred())
+
+		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		stopMgr := startTestManager(mgr)
+		defer stopMgr()
+
+		By("creating HTTPProxy")
+		hpKey := client.ObjectKey{Name: "foo", Namespace: ns}
+		Expect(k8sClient.Create(context.Background(), newDummyHTTPProxy(hpKey))).ShouldNot(HaveOccurred())
+
+		objKey := client.ObjectKey{
+			Name:      prefix + hpKey.Name,
+			Namespace: hpKey.Namespace,
+		}
+		By("getting Certificate with prefixed name")
+		crt := certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(1)))
+
+		By("updating HTTPProxy")
+
+		latest := &projectcontourv1.HTTPProxy{}
+		Expect(k8sClient.Get(context.Background(), hpKey, latest)).To(Succeed())
+		base := latest.DeepCopy()
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		latest.Annotations["foo"] = "bar"
+
+		Expect(k8sClient.Patch(context.Background(), latest, client.MergeFrom(base))).To(Succeed())
+
+		By("getting Certificate with prefixed name again")
+		crt = certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(1))) // should go through queue once (create)
+	})
+
+	It("should update Certificate via workqueue when spec is updated", func() {
+		scm, mgr := setupManager()
+
+		prefix := "test-"
+		opts := ReconcilerOptions{
+			ServiceKey:            testServiceKey,
+			Prefix:                prefix,
+			DefaultIssuerName:     "test-issuer",
+			DefaultIssuerKind:     IssuerKind,
+			CreateDNSEndpoint:     true,
+			CreateCertificate:     true,
+			CertificateApplyLimit: 1,
+		}
+		applyWorker := &WrappedCertificateApplyWorker{
+			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
+		}
+		Expect(mgr.Add(applyWorker)).ShouldNot(HaveOccurred())
+
+		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		stopMgr := startTestManager(mgr)
+		defer stopMgr()
+
+		By("creating HTTPProxy")
+		hpKey := client.ObjectKey{Name: "foo", Namespace: ns}
+		Expect(k8sClient.Create(context.Background(), newDummyHTTPProxy(hpKey))).ShouldNot(HaveOccurred())
+
+		objKey := client.ObjectKey{
+			Name:      prefix + hpKey.Name,
+			Namespace: hpKey.Namespace,
+		}
+		By("getting Certificate with prefixed name")
+		crt := certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(1)))
+
+		By("updating HTTPProxy")
+		latest := &projectcontourv1.HTTPProxy{}
+		Expect(k8sClient.Get(context.Background(), hpKey, latest)).To(Succeed())
+		base := latest.DeepCopy()
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		latest.Annotations[privateKeyAlgorithmAnnotation] = "ECDSA" // changing privateKeyAlgorithm should trigger reissuance of the Certificate
+
+		Expect(k8sClient.Patch(context.Background(), latest, client.MergeFrom(base))).To(Succeed())
+
+		time.Sleep(5 * time.Second) // wait for the certificate changes to be applied via rate limited queue
+		By("getting Certificate with prefixed name again")
+		crt = certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), objKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(2))) // should go through queue twice (create & update)
+	})
+}

--- a/controllers/certificate_worker_test.go
+++ b/controllers/certificate_worker_test.go
@@ -2,20 +2,37 @@ package controllers
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+var _ ApplyWorker[*cmv1.Certificate] = &WrappedCertificateApplyWorker{}
+
 type WrappedCertificateApplyWorker struct {
-	wrapped       *CertificateApplyWorker
-	queuedCounter atomic.Uint64
+	wrapped *CertificateApplyWorker
+
+	mu sync.Mutex
+	// tracked globally since the rate limit is global
+	queuedCounter uint64
+
+	// how many times Apply was called for this Certificate
+	// tracked per key for the ease of use
+	applyCounts map[types.NamespacedName]uint64
+
+	// how many initial attempts should fail before
+	// we pass through to the wrapped worker.
+	// tracked per key for the ease of use
+	failFirst map[types.NamespacedName]uint64
 }
 
 func (w *WrappedCertificateApplyWorker) Apply(ctx context.Context, obj *cmv1.Certificate) error {
@@ -24,21 +41,99 @@ func (w *WrappedCertificateApplyWorker) Apply(ctx context.Context, obj *cmv1.Cer
 	if err != nil {
 		return err
 	}
-	if requiresQueue {
-		w.queuedCounter.Add(1)
-	}
-	return w.wrapped.Apply(ctx, obj)
+
+	newObj := func() *cmv1.Certificate {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if requiresQueue {
+			w.queuedCounter += 1
+		}
+
+		if _, ok := w.applyCounts[objKey]; !ok {
+			w.applyCounts[objKey] = 0
+		}
+		w.applyCounts[objKey] += 1
+
+		if _, ok := w.failFirst[objKey]; !ok {
+			return obj
+		}
+
+		if w.applyCounts[objKey] <= w.failFirst[objKey] {
+			// fail by manipulating obj's spec
+			newObj := obj.DeepCopy()
+			// set invalid algorithm that should be rejected by the apiserver
+			// see https://github.com/cert-manager/cert-manager/blob/master/pkg/apis/certmanager/v1/types_certificate.go#L371-L377
+			newObj.Spec.PrivateKey = &cmv1.CertificatePrivateKey{
+				Algorithm: cmv1.PrivateKeyAlgorithm("SUPERSECURE"),
+			}
+			return newObj
+		}
+		return obj
+	}()
+	return w.wrapped.Apply(ctx, newObj)
 }
 
 func (w *WrappedCertificateApplyWorker) Start(ctx context.Context) error {
 	return w.wrapped.Start(ctx)
 }
 
+func (w *WrappedCertificateApplyWorker) GetRetryChannel() <-chan event.TypedGenericEvent[*projectcontourv1.HTTPProxy] {
+	return w.wrapped.GetRetryChannel()
+}
+
 func (w *WrappedCertificateApplyWorker) GetQueuedCounter() uint64 {
-	return w.queuedCounter.Load()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.queuedCounter
+}
+
+func (w *WrappedCertificateApplyWorker) GetApplyCounts(objKey types.NamespacedName) uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.applyCounts[objKey]
+}
+
+func (w *WrappedCertificateApplyWorker) SetFailFirstNForKey(objKey types.NamespacedName, n uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.failFirst[objKey] = n
+}
+
+func NewWrappedCertificateApplyWorker(wrapped *CertificateApplyWorker) *WrappedCertificateApplyWorker {
+	return &WrappedCertificateApplyWorker{
+		wrapped:     wrapped,
+		applyCounts: make(map[types.NamespacedName]uint64),
+		failFirst:   make(map[types.NamespacedName]uint64),
+	}
 }
 
 func testCertificateApplyWorkerApply() {
+	var ns string
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		// Let apiserver generate a unique name to avoid collisions.
+		n := &corev1.Namespace{
+			ObjectMeta: ctrl.ObjectMeta{
+				GenerateName: testNamespacePrefix,
+			},
+		}
+		Expect(k8sClient.Create(ctx, n)).To(Succeed())
+		ns = n.Name
+	})
+
+	AfterEach(func() {
+		// delete any resource created by the previous spec
+		Expect(k8sClient.DeleteAllOf(ctx, &projectcontourv1.HTTPProxy{}, client.InNamespace(ns))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, certificate(), client.InNamespace(ns))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, dnsEndpoint(), client.InNamespace(ns))).To(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, tlsCertificateDelegation(), client.InNamespace(ns))).To(Succeed())
+
+		n := &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: ns}}
+		_ = k8sClient.Delete(ctx, n) // this actually does not remove the namespace, it just puts it into terminating state
+	})
+
 	It("should create Certificate via workqueue", func() {
 		scm, mgr := setupManager()
 
@@ -52,9 +147,8 @@ func testCertificateApplyWorkerApply() {
 			CreateCertificate:     true,
 			CertificateApplyLimit: 1,
 		}
-		applyWorker := &WrappedCertificateApplyWorker{
-			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
-		}
+
+		applyWorker := NewWrappedCertificateApplyWorker(NewCertificateApplyWorker(mgr.GetClient(), opts))
 
 		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -107,9 +201,8 @@ func testCertificateApplyWorkerApply() {
 			PropagatedAnnotations: []string{"foo"}, // must propagate an annotation to update cert metadata
 			CertificateApplyLimit: 1,
 		}
-		applyWorker := &WrappedCertificateApplyWorker{
-			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
-		}
+
+		applyWorker := NewWrappedCertificateApplyWorker(NewCertificateApplyWorker(mgr.GetClient(), opts))
 
 		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -170,9 +263,8 @@ func testCertificateApplyWorkerApply() {
 			PropagatedAnnotations: []string{"foo"}, // must propagate an annotation to update cert metadata
 			CertificateApplyLimit: 1,
 		}
-		applyWorker := &WrappedCertificateApplyWorker{
-			wrapped: NewCertificateApplyWorker(mgr.GetClient(), opts),
-		}
+
+		applyWorker := NewWrappedCertificateApplyWorker(NewCertificateApplyWorker(mgr.GetClient(), opts))
 
 		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -213,5 +305,115 @@ func testCertificateApplyWorkerApply() {
 			return k8sClient.Get(context.Background(), objKey, crt)
 		}).WithTimeout(5 * time.Second).Should(Succeed())
 		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(2))) // should go through queue twice (create & update)
+	})
+
+	It("should create Certificate via workqueue after a retry", func() {
+		scm, mgr := setupManager()
+
+		prefix := "test-"
+		opts := ReconcilerOptions{
+			ServiceKey:            testServiceKey,
+			Prefix:                prefix,
+			DefaultIssuerName:     "test-issuer",
+			DefaultIssuerKind:     IssuerKind,
+			CreateDNSEndpoint:     true,
+			CreateCertificate:     true,
+			CertificateApplyLimit: 1,
+		}
+
+		applyWorker := NewWrappedCertificateApplyWorker(NewCertificateApplyWorker(mgr.GetClient(), opts))
+
+		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		stopMgr := startTestManager(mgr)
+		defer stopMgr()
+
+		By("creating HTTPProxy")
+		hpKey := client.ObjectKey{Name: "foo", Namespace: ns}
+		certObjKey := client.ObjectKey{
+			Name:      prefix + hpKey.Name,
+			Namespace: hpKey.Namespace,
+		}
+		r.CertApplier.(*WrappedCertificateApplyWorker).SetFailFirstNForKey(certObjKey, 1) // CertApply should fail once
+		Expect(k8sClient.Create(context.Background(), newDummyHTTPProxy(hpKey))).ShouldNot(HaveOccurred())
+
+		By("getting Certificate with prefixed name")
+		crt := certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), certObjKey, crt)
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(2)))
+		Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetApplyCounts(certObjKey)).Should(Equal(uint64(2)))
+	})
+
+	It("should create Certificate in the specified namespace via a workqueue after a retry", func() {
+		certNsObj := &corev1.Namespace{
+			ObjectMeta: ctrl.ObjectMeta{GenerateName: testNamespacePrefix},
+		}
+		Expect(k8sClient.Create(context.Background(), certNsObj)).ShouldNot(HaveOccurred())
+		certNs := certNsObj.Name
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, certNsObj)
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certNs}, &corev1.Namespace{})
+				return client.IgnoreNotFound(err) == nil
+			}, 10*time.Second).Should(BeTrue())
+		})
+
+		scm, mgr := setupManager()
+
+		opts := ReconcilerOptions{
+			ServiceKey:              testServiceKey,
+			CreateCertificate:       true,
+			DefaultIssuerKind:       IssuerKind,
+			DefaultIssuerName:       "test-issuer",
+			AllowedIssuerNamespaces: []string{certNs},
+			CertificateApplyLimit:   1,
+		}
+
+		applyWorker := NewWrappedCertificateApplyWorker(NewCertificateApplyWorker(mgr.GetClient(), opts))
+
+		r, err := SetupAndGetReconciler(mgr, scm, opts, applyWorker)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		stopMgr := startTestManager(mgr)
+		defer stopMgr()
+
+		By("creating HTTPProxy with Certificate namespace annotation")
+		hpKey := client.ObjectKey{Name: "foo", Namespace: ns}
+		hp := newDummyHTTPProxy(hpKey)
+		hp.Spec.VirtualHost.TLS = nil
+		hp.Annotations[issuerNamespaceAnnotation] = certNs
+
+		certName := hpKey.Namespace + "-" + hpKey.Name
+		certObjKey := client.ObjectKey{
+			Name:      certName,
+			Namespace: certNs,
+		}
+		r.CertApplier.(*WrappedCertificateApplyWorker).SetFailFirstNForKey(certObjKey, 1) // CertApply should fail once
+
+		Expect(k8sClient.Create(context.Background(), hp)).ShouldNot(HaveOccurred())
+
+		By("getting Certificate in the specified namespace")
+		crt := certificate()
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), certObjKey, crt)
+		}, 5*time.Second).Should(Succeed())
+		// NOTE: We are not checking the number of times the item went through the queue here
+		// since creating child resources in another namespace involves updating HTTPProxy, causing additional reconciliation.
+		// The timing of this reconciliation can vary and cause flakiness in this test case.
+		// should apply 2~3 times:
+		// 1. first apply
+		// 2. triggered by patch of HTTPProxy in `reconcileSecretName`
+		// 3. triggered by requeue
+		/* Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetQueuedCounter()).Should(Equal(uint64(3))) */
+		/* Expect(r.CertApplier.(*WrappedCertificateApplyWorker).GetApplyCounts(certObjKey)).Should(Equal(uint64(3))) */
+
+		By("ensuring HTTPProxy deletion deletes the Certificate")
+		Expect(k8sClient.Delete(context.Background(), hp)).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), certObjKey, crt)
+		}, 5*time.Second).ShouldNot(Succeed())
 	})
 }

--- a/controllers/certificate_worker_test.go
+++ b/controllers/certificate_worker_test.go
@@ -65,18 +65,12 @@ func (f *failingPatchClient) Patch(ctx context.Context, obj client.Object, patch
 }
 
 func testCertificateApplyWorker() {
-	var (
-		scheme *runtime.Scheme
-		ctx    context.Context
-	)
 
-	BeforeEach(func() {
-		ctx = context.Background()
+	ctx := context.Background()
 
-		scheme = runtime.NewScheme()
-		Expect(cmv1.AddToScheme(scheme)).To(Succeed())
-		Expect(projectcontourv1.AddToScheme(scheme)).To(Succeed())
-	})
+	scheme := runtime.NewScheme()
+	Expect(cmv1.AddToScheme(scheme)).To(Succeed())
+	Expect(projectcontourv1.AddToScheme(scheme)).To(Succeed())
 
 	newFakeClient := func(objs ...client.Object) client.Client {
 		return crfake.NewClientBuilder().
@@ -88,14 +82,10 @@ func testCertificateApplyWorker() {
 	Describe("Apply + RequiresQueue integration", func() {
 		// This test will not call Start so that items put into the queue does not get dequeued.
 		// This allows the inspection of the queue content withouot adding a wrapper.
-		var key types.NamespacedName
-
-		BeforeEach(func() {
-			key = types.NamespacedName{
-				Namespace: "default",
-				Name:      "test-cert",
-			}
-		})
+		key := types.NamespacedName{
+			Namespace: "default",
+			Name:      "test-cert",
+		}
 
 		It("queues a completely new object (NotFound path)", func() {
 			baseClient := newFakeClient() // no existing Certificate

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -629,6 +630,9 @@ func (r *HTTPProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// start worker if CertApplier requires one
 	if certWorker, ok := r.CertApplier.(ApplyWorker[*cmv1.Certificate]); ok {
 		if err := mgr.Add(certWorker); err != nil {
+			return err
+		}
+		if err := certWorker.RegisterMetrics(metrics.Registry); err != nil {
 			return err
 		}
 	}

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -427,19 +427,6 @@ func (r *HTTPProxyReconciler) reconcileTLSCertificateDelegation(ctx context.Cont
 		return nil
 	}
 	certificateName := getCertificateName(r, hp)
-
-	cert := &unstructured.Unstructured{}
-	cert.SetGroupVersionKind(certManagerGroupVersion.WithKind(CertificateKind))
-	certKey := client.ObjectKey{
-		Namespace: namespace,
-		Name:      certificateName,
-	}
-	err := r.Get(ctx, certKey, cert)
-	if k8serrors.IsNotFound(err) {
-		log.Info("Certificate not found for TLSCertificateDelegation", "namespace", namespace, "name", certificateName)
-		/* return err */
-	}
-
 	delegationSpec := map[string]interface{}{
 		"delegations": []map[string]interface{}{
 			{
@@ -458,7 +445,7 @@ func (r *HTTPProxyReconciler) reconcileTLSCertificateDelegation(ctx context.Cont
 	obj.SetAnnotations(r.generateObjectAnnotations(hp))
 	obj.SetLabels(r.generateObjectLabels(hp))
 	obj.UnstructuredContent()["spec"] = delegationSpec
-	err = r.trackResourceOwnership(hp, obj)
+	err := r.trackResourceOwnership(hp, obj)
 	if err != nil {
 		return err
 	}

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -816,15 +816,3 @@ func getDNSEndpointName(r *HTTPProxyReconciler, hp *projectcontourv1.HTTPProxy) 
 	}
 	return r.Prefix + hp.Namespace + "-" + hp.Name
 }
-
-func extractOwner(nn string) (namespace, name string, ok bool) {
-	parts := strings.Split(nn, "/")
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	ns, name := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
-	if ns == "" || name == "" {
-		return "", "", false
-	}
-	return ns, name, true
-}

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +52,8 @@ type HTTPProxyReconciler struct {
 	ReconcilerOptions
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+
+	CertApplier Applier[*cmv1.Certificate]
 }
 
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies,verbs=get;list;watch;update;patch
@@ -308,23 +312,23 @@ func (r *HTTPProxyReconciler) reconcileCertificate(ctx context.Context, hp *proj
 		return nil
 	}
 
-	certificateSpec := map[string]interface{}{
-		"dnsNames":   []string{vh.Fqdn},
-		"secretName": secretName,
-		"commonName": vh.Fqdn,
-		"issuerRef": map[string]interface{}{
-			"kind": issuerKind,
-			"name": issuerName,
+	certificateSpec := cmv1.CertificateSpec{
+		DNSNames:   []string{vh.Fqdn},
+		SecretName: secretName,
+		CommonName: vh.Fqdn,
+		IssuerRef: cmmeta.IssuerReference{
+			Kind: issuerKind,
+			Name: issuerName,
 		},
-		"usages": []string{
-			usageDigitalSignature,
-			usageKeyEncipherment,
-			usageServerAuth,
+		Usages: []cmv1.KeyUsage{
+			cmv1.UsageDigitalSignature,
+			cmv1.UsageKeyEncipherment,
+			cmv1.UsageServerAuth,
 		},
 	}
 
 	if r.CSRRevisionLimit > 0 {
-		certificateSpec["revisionHistoryLimit"] = r.CSRRevisionLimit
+		certificateSpec.RevisionHistoryLimit = ptr.To(int32(r.CSRRevisionLimit))
 	}
 	if value, ok := hp.Annotations[revisionHistoryLimitAnnotation]; ok {
 		limit, err := strconv.ParseUint(value, 10, 32)
@@ -332,34 +336,34 @@ func (r *HTTPProxyReconciler) reconcileCertificate(ctx context.Context, hp *proj
 			log.Error(err, "invalid revisionHistoryLimit", "value", value)
 			return nil
 		}
-		certificateSpec["revisionHistoryLimit"] = limit
+		certificateSpec.RevisionHistoryLimit = ptr.To(int32(limit))
 	}
-	secretTemplate := make(map[string]interface{})
+	secretTemplate := &cmv1.CertificateSecretTemplate{}
 	annotations := r.generateObjectAnnotations(hp)
 	if annotations != nil {
-		secretTemplate["annotations"] = annotations
+		secretTemplate.Annotations = annotations
 	}
 	labels := r.generateObjectLabels(hp)
 	if labels != nil {
-		secretTemplate["labels"] = labels
+		secretTemplate.Labels = labels
 	}
-	if len(secretTemplate) > 0 {
-		certificateSpec["secretTemplate"] = secretTemplate
+	if secretTemplate.Annotations != nil || secretTemplate.Labels != nil {
+		certificateSpec.SecretTemplate = secretTemplate
 	}
 
 	if algorithm, ok := hp.Annotations[privateKeyAlgorithmAnnotation]; ok {
-		privateKeySpec := map[string]interface{}{
-			"algorithm": algorithm,
+		privateKeySpec := &cmv1.CertificatePrivateKey{
+			Algorithm: cmv1.PrivateKeyAlgorithm(algorithm),
 		}
 		if value, ok := hp.Annotations[privateKeySizeAnnotation]; ok {
 			size, err := strconv.ParseUint(value, 10, 32)
 			if err == nil {
-				privateKeySpec["size"] = size
+				privateKeySpec.Size = int(size)
 			} else {
 				log.Error(err, "invalid privateKey size", "value", value)
 			}
 		}
-		certificateSpec["privateKey"] = privateKeySpec
+		certificateSpec.PrivateKey = privateKeySpec
 	}
 
 	certificateName := getCertificateName(r, hp)
@@ -368,11 +372,11 @@ func (r *HTTPProxyReconciler) reconcileCertificate(ctx context.Context, hp *proj
 		targetNamespace = ns
 	}
 
-	obj := &unstructured.Unstructured{}
+	obj := &cmv1.Certificate{}
 	obj.SetGroupVersionKind(certManagerGroupVersion.WithKind(CertificateKind))
 	obj.SetName(certificateName)
 	obj.SetNamespace(targetNamespace)
-	obj.UnstructuredContent()["spec"] = certificateSpec
+	obj.Spec = certificateSpec
 
 	obj.SetAnnotations(annotations)
 	obj.SetLabels(labels)
@@ -381,16 +385,7 @@ func (r *HTTPProxyReconciler) reconcileCertificate(ctx context.Context, hp *proj
 	if err != nil {
 		return err
 	}
-	err = r.Patch(ctx, obj, client.Apply, &client.PatchOptions{
-		Force:        ptr.To(true),
-		FieldManager: "contour-plus",
-	})
-	if err != nil {
-		return err
-	}
-
-	log.Info("Certificate successfully reconciled")
-	return nil
+	return r.CertApplier.Apply(ctx, obj)
 }
 
 // generateObjectAnnotations creates a map that contains annotations that should be propagated to child resources from HTTPProxy.
@@ -498,7 +493,7 @@ func (r *HTTPProxyReconciler) reconcileSecretName(ctx context.Context, hp *proje
 	return nil
 }
 
-func (r *HTTPProxyReconciler) trackResourceForCleanup(hp *projectcontourv1.HTTPProxy, obj *unstructured.Unstructured) error {
+func (r *HTTPProxyReconciler) trackResourceForCleanup(hp *projectcontourv1.HTTPProxy, obj client.Object) error {
 	if obj.GetNamespace() == hp.Namespace {
 		return ctrl.SetControllerReference(hp, obj, r.Scheme)
 	}
@@ -643,6 +638,12 @@ func (r *HTTPProxyReconciler) cleanupCrossNamespaceTLSCertificateDelegations(ctx
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *HTTPProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// start worker if CertApplier requires one
+	if certWorker, ok := r.CertApplier.(ApplyWorker[*cmv1.Certificate]); ok {
+		if err := mgr.Add(certWorker); err != nil {
+			return err
+		}
+	}
 	listHPs := func(ctx context.Context, a client.Object) []reconcile.Request {
 		if a.GetNamespace() != r.ServiceKey.Namespace {
 			return nil
@@ -726,9 +727,7 @@ func (r *HTTPProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		b = b.Owns(obj, builder.WithPredicates(ignoreChildCreateEvent, predicate.GenerationChangedPredicate{}))
 	}
 	if r.CreateCertificate {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(certManagerGroupVersion.WithKind(CertificateKind))
-		b = b.Owns(obj, builder.WithPredicates(ignoreChildCreateEvent, predicate.GenerationChangedPredicate{}))
+		b = b.Owns(&cmv1.Certificate{}, builder.WithPredicates(ignoreChildCreateEvent, predicate.GenerationChangedPredicate{}))
 		tcdObj := &unstructured.Unstructured{}
 		tcdObj.SetGroupVersionKind(contourGroupVersion.WithKind(TLSCertificateDelegationKind))
 		b = b.Owns(tcdObj, builder.WithPredicates(ignoreChildCreateEvent, predicate.GenerationChangedPredicate{}))

--- a/controllers/httpproxy_controller_test.go
+++ b/controllers/httpproxy_controller_test.go
@@ -81,13 +81,6 @@ func testHTTPProxyReconcile() {
 		Expect(k8sClient.DeleteAllOf(ctx, dnsEndpoint(), client.InNamespace(ns))).To(Succeed())
 		Expect(k8sClient.DeleteAllOf(ctx, tlsCertificateDelegation(), client.InNamespace(ns))).To(Succeed())
 
-		// optionally wait for lists to be empty
-		Eventually(func() int {
-			l := &projectcontourv1.HTTPProxyList{}
-			_ = k8sClient.List(ctx, l, client.InNamespace(ns))
-			return len(l.Items)
-		}).Should(BeZero())
-
 		n := &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: ns}}
 		_ = k8sClient.Delete(ctx, n) // this actually does not remove the namespace, it just puts it into terminating state
 	})

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -44,9 +44,10 @@ func SetupScheme(scm *runtime.Scheme) {
 // SetupReconciler initializes reconcilers
 func SetupReconciler(mgr manager.Manager, scheme *runtime.Scheme, opts ReconcilerOptions) error {
 	var certWorker Applier[*cmapiv1.Certificate]
-	certWorker = NewCertificateApplier(mgr.GetClient())
 	if opts.CertificateApplyLimit > 0 {
 		certWorker = NewCertificateApplyWorker(mgr.GetClient(), opts)
+	} else {
+		certWorker = NewCertificateApplier(mgr.GetClient())
 	}
 	_, err := SetupAndGetReconciler(mgr, scheme, opts, certWorker)
 

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -56,7 +56,6 @@ func SetupReconciler(mgr manager.Manager, scheme *runtime.Scheme, opts Reconcile
 }
 
 // SetupAndGetReconciler initializes reconcilers and return the reconciler struct
-// c
 func SetupAndGetReconciler(mgr manager.Manager, scheme *runtime.Scheme, opts ReconcilerOptions, certWorker Applier[*cmapiv1.Certificate]) (*HTTPProxyReconciler, error) {
 	httpProxyReconciler := &HTTPProxyReconciler{
 		Client:            mgr.GetClient(),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -105,6 +105,10 @@ var _ = Describe("Test contour-plus", func() {
 	Context("httpproxy", testHTTPProxyReconcile)
 })
 
+var _ = Describe("Test Certificate apply worker", func() {
+	Context("certificate-apply-worker", testCertificateApplyWorkerApply)
+})
+
 func startTestManager(mgr manager.Manager) (stop func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Test contour-plus", func() {
 })
 
 var _ = Describe("Test Certificate apply worker", func() {
-	Context("certificate-apply-worker", testCertificateApplyWorkerApply)
+	Context("certificate-apply-worker", testCertificateApplyWorker)
 })
 
 func startTestManager(mgr manager.Manager) (stop func()) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cybozu-go/contour-plus
 go 1.25.4
 
 require (
+	github.com/cert-manager/cert-manager v1.19.1
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
@@ -10,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
+	golang.org/x/time v0.14.0
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
 	k8s.io/client-go v0.34.2
@@ -77,7 +79,6 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
@@ -85,6 +86,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
+	sigs.k8s.io/gateway-api v1.4.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/projectcontour/contour v1.33.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -54,12 +55,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cert-manager/cert-manager v1.19.1 h1:Txh8L/nLWTDcb7ZnXuXbTe15BxQnLbLirXmbNk0fGgY=
+github.com/cert-manager/cert-manager v1.19.1/go.mod h1:8Ps1VXCQRGKT8zNvLQlhDK1gFKWmYKdIPQFmvTS2JeA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -11,8 +13,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
+github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -233,6 +235,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/gateway-api v1.4.0 h1:ZwlNM6zOHq0h3WUX2gfByPs2yAEsy/EenYJB78jpQfQ=
+sigs.k8s.io/gateway-api v1.4.0/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
## Problem addressed in this PR
The current implementation of contour-plus provides no mechanism to control the rate at which Certificate resources are created. This can be problematic when a large number of Certificates need to be issued or re-issued in a short period of time, as it may trigger rate limits enforced by public CAs.

cert-manager itself also does not provide a way to directly control the rate at which Certificate issuance requests are sent to upstream CAs. As a result, the only practical control point available to contour-plus is the rate at which it creates Certificate resources.

## Solution
This PR introduces a simple queue + worker model in contour-plus to control the rate of Certificate resource creation.
A configurable rate limiter is applied to the worker responsible for creating Certificates, allowing operators to throttle Certificate issuance requests before they reach cert-manager and the upstream CA.

It is implemented using the rate limiter and workqueue provided in client-go packages.

The rate limit is configured via the command-line flag: `--certificate-apply-limit`
- The value is a float64 representing the maximum number of Certificate creations allowed per second.
- Passing a negative value results in an error.
- The feature is disabled by default (--certificate-apply-limit=0), in which case contour-plus behaves as before:
  - Certificates are created immediately
  - No queue or rate limiting is applied

## Some of the design choices I made
- Unified applier interface
The logic for applying Certificate resources is abstracted behind a common interface, allowing both queued (rate-limited) and non-queued (immediate) implementations to share the same call path.
- Controller-managed lifecycle
The workqueue–based applier is started during controller setup and registered as a runnable with the manager, ensuring that its lifecycle is tied to the controller and properly handled on startup and shutdown.
~~- Test visibility into apply path~~
~~The test code wraps the applier implementation to expose whether a Certificate was applied via the queue or directly, allowing tests to assert the correct behavior without coupling to internal implementation details.~~
  - removed the integration test with wrapper and refactored the majority of the new tests as unit test.