### PR TITLE
Add configurable exponential backoff for certificate apply retries

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -50,6 +51,8 @@ func init() {
 	fs.StringSlice("allowed-dns-namespaces", []string{}, "List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed")
 	fs.StringSlice("allowed-issuer-namespaces", []string{}, "List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed")
 	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
+	fs.Duration("certificate-apply-retry-base-delay", 5*time.Second, "Base delay for certificate apply exponential backoff retry")
+	fs.Duration("certificate-apply-retry-max-delay", 10*time.Minute, "Maximum delay for certificate apply exponential backoff retry")
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -51,8 +50,8 @@ func init() {
 	fs.StringSlice("allowed-dns-namespaces", []string{}, "List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed")
 	fs.StringSlice("allowed-issuer-namespaces", []string{}, "List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed")
 	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
-	fs.Duration("certificate-apply-retry-base-delay", 5*time.Second, "Base delay for certificate apply exponential backoff retry")
-	fs.Duration("certificate-apply-retry-max-delay", 10*time.Minute, "Maximum delay for certificate apply exponential backoff retry")
+	fs.Duration("certificate-apply-retry-base-delay", controllers.DefaultRetryBaseDelay, "Base delay for certificate apply exponential backoff retry")
+	fs.Duration("certificate-apply-retry-max-delay", controllers.DefaultRetryMaxDelay, "Maximum delay for certificate apply exponential backoff retry")
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,6 +83,12 @@ func run() error {
 		return errors.New("certificate-apply-limit must be greater than or equal to 0")
 	}
 
+	opts.CertificateApplyRetryBaseDelay = viper.GetDuration("certificate-apply-retry-base-delay")
+	opts.CertificateApplyRetryMaxDelay = viper.GetDuration("certificate-apply-retry-max-delay")
+	if opts.CertificateApplyRetryMaxDelay < opts.CertificateApplyRetryBaseDelay {
+		return errors.New("certificate-apply-retry-max-delay must be greater than or equal to certificate-apply-retry-base-delay")
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -84,7 +84,13 @@ func run() error {
 	}
 
 	opts.CertificateApplyRetryBaseDelay = viper.GetDuration("certificate-apply-retry-base-delay")
+	if opts.CertificateApplyRetryBaseDelay <= 0 {
+		return errors.New("certificate-apply-retry-base-delay must be greater than 0")
+	}
 	opts.CertificateApplyRetryMaxDelay = viper.GetDuration("certificate-apply-retry-max-delay")
+	if opts.CertificateApplyRetryMaxDelay <= 0 {
+		return errors.New("certificate-apply-retry-max-delay must be greater than 0")
+	}
 	if opts.CertificateApplyRetryMaxDelay < opts.CertificateApplyRetryBaseDelay {
 		return errors.New("certificate-apply-retry-max-delay must be greater than or equal to certificate-apply-retry-base-delay")
 	}

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -34,6 +35,9 @@ const (
 	labelApplyResult                        = "result"
 	applyResultSuccess     applyResultValue = "success"
 	applyResultError       applyResultValue = "error"
+
+	defaultRetryBaseDelay = 5 * time.Second
+	defaultRetryMaxDelay  = 10 * time.Minute
 )
 
 type Applier[T client.Object] interface {
@@ -103,9 +107,19 @@ func NewCertificateApplyWorker(client client.Client, opt ReconcilerOptions) *Cer
 		limiter = rate.NewLimiter(rate.Limit(limit), burst)
 	}
 
+	retryBaseDelay := opt.CertificateApplyRetryBaseDelay
+	if retryBaseDelay <= 0 {
+		retryBaseDelay = defaultRetryBaseDelay
+	}
+	retryMaxDelay := opt.CertificateApplyRetryMaxDelay
+	if retryMaxDelay <= 0 {
+		retryMaxDelay = defaultRetryMaxDelay
+	}
+
 	global := &workqueue.TypedBucketRateLimiter[types.NamespacedName]{Limiter: limiter}
-	workqueue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		global,
+	expFailure := workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](retryBaseDelay, retryMaxDelay)
+	certQueue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.NewTypedMaxOfRateLimiter(global, expFailure),
 		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
 			Name: certificateApplierName,
 		},
@@ -114,7 +128,7 @@ func NewCertificateApplyWorker(client client.Client, opt ReconcilerOptions) *Cer
 	return &CertificateApplyWorker{
 		ReconcilerOptions: opt,
 		client:            client,
-		workqueue:         workqueue,
+		workqueue:         certQueue,
 		manifests:         make(map[types.NamespacedName]*cmv1.Certificate),
 		limiter:           limiter,
 		retryCh:           retryCh,
@@ -182,7 +196,6 @@ func (w *CertificateApplyWorker) Start(ctx context.Context) error {
 		log.Info("processing cert queue item", "key", objKey.String())
 
 		func() {
-			// there is no need to call .Forget since we are only using BucketRateLimiter
 			defer w.workqueue.Done(objKey)
 
 			w.mu.Lock()
@@ -209,6 +222,9 @@ func (w *CertificateApplyWorker) Start(ctx context.Context) error {
 
 			log.Info("cert applied from queue", "key", objKey.String())
 			w.recordApply(viaQueueYes, applyResultSuccess)
+			// Forget the cert key to reset the exponential backoff counter so that
+			// a future failure starts from the base delay again.
+			w.workqueue.Forget(objKey)
 		}()
 	}
 }
@@ -250,36 +266,41 @@ func (w *CertificateApplyWorker) enqueueCertificate(objKey types.NamespacedName,
 	w.workqueue.AddRateLimited(objKey)
 }
 
-// enqueueHTTPProxy enqueues HTTPProxy in to the workqueue used by the main Reconcile function.
-// It requires the Controller to be setup with .WatchesRawSource using the same channel as w.retryCh
+// enqueueHTTPProxy sends the HTTPProxy that owns obj directly to retryCh so the main
+// reconcile loop picks it up. The exponential backoff is handled by the certQueue's
+// MaxOfRateLimiter when the reconcile loop calls AddRateLimited on subsequent failures.
 func (w *CertificateApplyWorker) enqueueHTTPProxy(ctx context.Context, obj *cmv1.Certificate) {
 	log := crlog.FromContext(ctx)
-	if w.retryCh == nil {
-		return
-	}
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		log.Error(fmt.Errorf("annotation does not exist"), "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
-		return
-	}
-	owner, ok := annotations[ownerAnnotation]
-	if !ok {
-		log.Error(fmt.Errorf("annotation not found for %s", ownerAnnotation), "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
-		return
-	}
-
-	ns, name, err := cache.SplitMetaNamespaceKey(owner)
+	httpProxyKey, err := getHTTPProxyKey(obj)
 	if err != nil {
 		log.Error(err, "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
 		return
 	}
-	h := projectcontourv1.HTTPProxy{}
-	h.SetNamespace(ns)
-	h.SetName(name)
-	log.Info("re-queueing HTTPProxy", "namespace", ns, "name", name)
-	w.retryCh <- event.TypedGenericEvent[*projectcontourv1.HTTPProxy]{
-		Object: &h,
+	h := &projectcontourv1.HTTPProxy{}
+	h.SetNamespace(httpProxyKey.Namespace)
+	h.SetName(httpProxyKey.Name)
+	log.Info("re-queueing HTTPProxy for retry", "namespace", httpProxyKey.Namespace, "name", httpProxyKey.Name)
+	select {
+	case w.retryCh <- event.TypedGenericEvent[*projectcontourv1.HTTPProxy]{Object: h}:
+	case <-ctx.Done():
 	}
+}
+
+// getHTTPProxyKey extracts the owning HTTPProxy NamespacedName from the certificate's owner annotation.
+func getHTTPProxyKey(obj *cmv1.Certificate) (types.NamespacedName, error) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return types.NamespacedName{}, fmt.Errorf("annotations do not exist on certificate %s/%s", obj.Namespace, obj.Name)
+	}
+	owner, ok := annotations[ownerAnnotation]
+	if !ok {
+		return types.NamespacedName{}, fmt.Errorf("annotation %q not found on certificate %s/%s", ownerAnnotation, obj.Namespace, obj.Name)
+	}
+	ns, name, err := cache.SplitMetaNamespaceKey(owner)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+	return types.NamespacedName{Namespace: ns, Name: name}, nil
 }
 
 func (w *CertificateApplyWorker) recordApply(viaQueue viaQueueValue, applyResult applyResultValue) {

--- a/controllers/certificate_worker.go
+++ b/controllers/certificate_worker.go
@@ -36,8 +36,8 @@ const (
 	applyResultSuccess     applyResultValue = "success"
 	applyResultError       applyResultValue = "error"
 
-	defaultRetryBaseDelay = 5 * time.Second
-	defaultRetryMaxDelay  = 10 * time.Minute
+	DefaultRetryBaseDelay = 5 * time.Second
+	DefaultRetryMaxDelay  = 10 * time.Minute
 )
 
 type Applier[T client.Object] interface {
@@ -107,17 +107,8 @@ func NewCertificateApplyWorker(client client.Client, opt ReconcilerOptions) *Cer
 		limiter = rate.NewLimiter(rate.Limit(limit), burst)
 	}
 
-	retryBaseDelay := opt.CertificateApplyRetryBaseDelay
-	if retryBaseDelay <= 0 {
-		retryBaseDelay = defaultRetryBaseDelay
-	}
-	retryMaxDelay := opt.CertificateApplyRetryMaxDelay
-	if retryMaxDelay <= 0 {
-		retryMaxDelay = defaultRetryMaxDelay
-	}
-
 	global := &workqueue.TypedBucketRateLimiter[types.NamespacedName]{Limiter: limiter}
-	expFailure := workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](retryBaseDelay, retryMaxDelay)
+	expFailure := workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](opt.CertificateApplyRetryBaseDelay, opt.CertificateApplyRetryMaxDelay)
 	certQueue := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.NewTypedMaxOfRateLimiter(global, expFailure),
 		workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{
@@ -271,36 +262,29 @@ func (w *CertificateApplyWorker) enqueueCertificate(objKey types.NamespacedName,
 // MaxOfRateLimiter when the reconcile loop calls AddRateLimited on subsequent failures.
 func (w *CertificateApplyWorker) enqueueHTTPProxy(ctx context.Context, obj *cmv1.Certificate) {
 	log := crlog.FromContext(ctx)
-	httpProxyKey, err := getHTTPProxyKey(obj)
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		log.Error(fmt.Errorf("annotations do not exist on certificate %s/%s", obj.Namespace, obj.Name), "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
+		return
+	}
+	owner, ok := annotations[ownerAnnotation]
+	if !ok {
+		log.Error(fmt.Errorf("annotation %q not found on certificate %s/%s", ownerAnnotation, obj.Namespace, obj.Name), "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
+		return
+	}
+	ns, name, err := cache.SplitMetaNamespaceKey(owner)
 	if err != nil {
 		log.Error(err, "skipping HTTPProxy enqueue", "certificateName", obj.Name, "certificateNamespace", obj.Namespace)
 		return
 	}
 	h := &projectcontourv1.HTTPProxy{}
-	h.SetNamespace(httpProxyKey.Namespace)
-	h.SetName(httpProxyKey.Name)
-	log.Info("re-queueing HTTPProxy for retry", "namespace", httpProxyKey.Namespace, "name", httpProxyKey.Name)
+	h.SetNamespace(ns)
+	h.SetName(name)
+	log.Info("re-queueing HTTPProxy for retry", "namespace", ns, "name", name)
 	select {
 	case w.retryCh <- event.TypedGenericEvent[*projectcontourv1.HTTPProxy]{Object: h}:
 	case <-ctx.Done():
 	}
-}
-
-// getHTTPProxyKey extracts the owning HTTPProxy NamespacedName from the certificate's owner annotation.
-func getHTTPProxyKey(obj *cmv1.Certificate) (types.NamespacedName, error) {
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		return types.NamespacedName{}, fmt.Errorf("annotations do not exist on certificate %s/%s", obj.Namespace, obj.Name)
-	}
-	owner, ok := annotations[ownerAnnotation]
-	if !ok {
-		return types.NamespacedName{}, fmt.Errorf("annotation %q not found on certificate %s/%s", ownerAnnotation, obj.Namespace, obj.Name)
-	}
-	ns, name, err := cache.SplitMetaNamespaceKey(owner)
-	if err != nil {
-		return types.NamespacedName{}, err
-	}
-	return types.NamespacedName{Namespace: ns, Name: name}, nil
 }
 
 func (w *CertificateApplyWorker) recordApply(viaQueue viaQueueValue, applyResult applyResultValue) {

--- a/controllers/certificate_worker_test.go
+++ b/controllers/certificate_worker_test.go
@@ -93,7 +93,9 @@ func testCertificateApplyWorker() {
 			baseClient := newFakeClient() // no existing Certificate
 			cl := &applyAsUpdateClient{Client: baseClient}
 			worker := NewCertificateApplyWorker(cl, ReconcilerOptions{
-				CertificateApplyLimit: 10, // avoid rate.Limit(0) semantics
+				CertificateApplyLimit:          10, // avoid rate.Limit(0) semantics
+				CertificateApplyRetryBaseDelay: 1 * time.Millisecond,
+				CertificateApplyRetryMaxDelay:  10 * time.Millisecond,
 			})
 
 			reg := prometheus.NewRegistry()
@@ -120,7 +122,7 @@ func testCertificateApplyWorker() {
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "new object should not be applied immediately, but queued")
 
 			// And the worker should have the key in its internal queue
-			Expect(worker.workqueue.Len()).To(Equal(1))
+			Eventually(func() int { return worker.workqueue.Len() }, 500*time.Millisecond, time.Millisecond).Should(Equal(1))
 
 			queuedKey, shutdown := worker.workqueue.Get()
 			Expect(shutdown).To(BeFalse())
@@ -207,7 +209,9 @@ func testCertificateApplyWorker() {
 			baseClient := newFakeClient(current) // init with a certificate
 			cl := &applyAsUpdateClient{Client: baseClient}
 			worker := NewCertificateApplyWorker(cl, ReconcilerOptions{
-				CertificateApplyLimit: 10,
+				CertificateApplyLimit:          10,
+				CertificateApplyRetryBaseDelay: 1 * time.Millisecond,
+				CertificateApplyRetryMaxDelay:  10 * time.Millisecond,
 			})
 
 			reg := prometheus.NewRegistry()
@@ -221,7 +225,7 @@ func testCertificateApplyWorker() {
 			Expect(worker.Apply(ctx, desired)).To(Succeed())
 
 			// Should be queued, not applied directly
-			Expect(worker.workqueue.Len()).To(Equal(1))
+			Eventually(func() int { return worker.workqueue.Len() }, 500*time.Millisecond, time.Millisecond).Should(Equal(1))
 
 			// The object in the fake client should still be the old spec (no extra DNS yet),
 			// because the queued apply hasn’t run Start() / processed the queue.
@@ -250,7 +254,9 @@ func testCertificateApplyWorker() {
 			baseClient := newFakeClient() // no existing certificate
 			cl := &applyAsUpdateClient{Client: baseClient}
 			worker := NewCertificateApplyWorker(cl, ReconcilerOptions{
-				CertificateApplyLimit: 10, // avoid rate.Limit(0) oddness
+				CertificateApplyLimit:          10, // avoid rate.Limit(0) oddness
+				CertificateApplyRetryBaseDelay: 1 * time.Millisecond,
+				CertificateApplyRetryMaxDelay:  10 * time.Millisecond,
 			})
 
 			reg := prometheus.NewRegistry()
@@ -318,7 +324,9 @@ func testCertificateApplyWorker() {
 			cl := &failingPatchClient{Client: baseClient}
 
 			worker := NewCertificateApplyWorker(cl, ReconcilerOptions{
-				CertificateApplyLimit: 10,
+				CertificateApplyLimit:          10,
+				CertificateApplyRetryBaseDelay: 100 * time.Millisecond,
+				CertificateApplyRetryMaxDelay:  1 * time.Second,
 			})
 
 			reg := prometheus.NewRegistry()
@@ -350,11 +358,12 @@ func testCertificateApplyWorker() {
 			// Apply should enqueue the certificate (RequiresQueue returns true for new object)
 			Expect(worker.Apply(ctx, cert)).To(Succeed())
 
-			// We expect a retry event on the channel because Patch always fails
+			// We expect a retry event on the channel because Patch always fails.
+			// The event is delayed by CertificateApplyRetryBaseDelay (100ms) due to the exponential backoff queue.
 			retryCh := worker.GetRetryChannel()
 
 			var evt event.TypedGenericEvent[*projectcontourv1.HTTPProxy]
-			Eventually(retryCh, 2*time.Second, 100*time.Millisecond).Should(
+			Eventually(retryCh, 5*time.Second, 100*time.Millisecond).Should(
 				Receive(&evt),
 				"expected an HTTPProxy event to be sent on retry channel after apply failure",
 			)

--- a/controllers/httpproxy_controller_test.go
+++ b/controllers/httpproxy_controller_test.go
@@ -1391,14 +1391,16 @@ func testHTTPProxyReconcile() {
 
 		prefix := "test-"
 		opts := ReconcilerOptions{
-			ServiceKey:            testServiceKey,
-			Prefix:                prefix,
-			DefaultIssuerName:     "test-issuer",
-			DefaultIssuerKind:     IssuerKind,
-			CreateDNSEndpoint:     true,
-			CreateCertificate:     true,
-			PropagatedAnnotations: []string{"foo"}, // must propagate an annotation to update cert metadata
-			CertificateApplyLimit: 1,
+			ServiceKey:                     testServiceKey,
+			Prefix:                         prefix,
+			DefaultIssuerName:              "test-issuer",
+			DefaultIssuerKind:              IssuerKind,
+			CreateDNSEndpoint:              true,
+			CreateCertificate:              true,
+			PropagatedAnnotations:          []string{"foo"}, // must propagate an annotation to update cert metadata
+			CertificateApplyLimit:          1,
+			CertificateApplyRetryBaseDelay: 1 * time.Millisecond,
+			CertificateApplyRetryMaxDelay:  10 * time.Millisecond,
 		}
 
 		err := SetupReconciler(mgr, scm, opts)

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"time"
+
 	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,22 +16,24 @@ import (
 
 // ReconcilerOptions is a set of options for reconcilers
 type ReconcilerOptions struct {
-	ServiceKey              client.ObjectKey
-	Prefix                  string
-	DefaultIssuerName       string
-	DefaultIssuerKind       string
-	DefaultDelegatedDomain  string
-	AllowedDelegatedDomains []string
-	AllowCustomDelegations  bool
-	CSRRevisionLimit        uint
-	CreateDNSEndpoint       bool
-	CreateCertificate       bool
-	IngressClassName        string
-	PropagatedAnnotations   []string
-	PropagatedLabels        []string
-	AllowedDNSNamespaces    []string
-	AllowedIssuerNamespaces []string
-	CertificateApplyLimit   float64
+	ServiceKey                     client.ObjectKey
+	Prefix                         string
+	DefaultIssuerName              string
+	DefaultIssuerKind              string
+	DefaultDelegatedDomain         string
+	AllowedDelegatedDomains        []string
+	AllowCustomDelegations         bool
+	CSRRevisionLimit               uint
+	CreateDNSEndpoint              bool
+	CreateCertificate              bool
+	IngressClassName               string
+	PropagatedAnnotations          []string
+	PropagatedLabels               []string
+	AllowedDNSNamespaces           []string
+	AllowedIssuerNamespaces        []string
+	CertificateApplyLimit          float64
+	CertificateApplyRetryBaseDelay time.Duration
+	CertificateApplyRetryMaxDelay  time.Duration
 }
 
 // SetupScheme initializes a schema


### PR DESCRIPTION
Summary:

This PR implements exponential backoff for retrying failed certificate apply operations in `CertificateApplyWorker`.

Previously, when a certificate apply failed, the owning HTTPProxy was sent to `retryCh` and the reconcile loop would immediately re-enqueue the Certificate key to `certQueue` via `AddRateLimited`. Since `certQueue` only had a global `BucketRateLimiter`, each failed retry consumed a rate limit token, exhausting the budget. This change replaces the global-only rate limiter with a MaxOf combinator of the global `BucketRateLimiter` and a `TypedItemExponentialFailureRateLimiter`, so that per-Certificate-key backoff controls how quickly a key is released from the queue after repeated failures. The base and maximum delays are configurable via CLI flags.

Changes:

- certQueue now uses `MaxOfRateLimiter`(`BucketRateLimiter`, `ItemExponentialFailureRateLimiter`), giving per-item exponential backoff in addition to the existing global throughput limit. On success, Forget resets the failure counter so the next failure starts from the base delay again.
- Add `--certificate-apply-retry-base-delay` (default 5s) and `--certificate-apply-retry-max-delay` (default 10m) CLI flags。
- Expose these as `CertificateApplyRetryBaseDelay` / `CertificateApplyRetryMaxDelay` on `ReconcilerOptions`.
- Validate at startup that max-delay >= base-delay.

