### PR TITLE
Handle wildcard FQDN correctly

### DIFF
--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -774,6 +774,7 @@ func ipsToTargets(ips []net.IP) ([]string, []string) {
 
 func makeDelegationEndpoint(hostname, delegatedDomain string) []map[string]interface{} {
 	fqdn := strings.Trim(hostname, ".")
+	fqdn = strings.TrimPrefix(fqdn, "*.")
 	return []map[string]interface{}{
 		{
 			"dnsName":    "_acme-challenge." + fqdn,

--- a/controllers/httpproxy_controller_test.go
+++ b/controllers/httpproxy_controller_test.go
@@ -1682,6 +1682,20 @@ func TestMakeDelegationEndpoint(t *testing.T) {
 			expectDNSName:   "_acme-challenge.example.com",
 			expectTarget:    "_acme-challenge.example.com.delegated.com",
 		},
+		{
+			name:            "Wildcard hostname",
+			hostname:        "*.example.com",
+			delegatedDomain: "delegated.com",
+			expectDNSName:   "_acme-challenge.example.com",
+			expectTarget:    "_acme-challenge.example.com.delegated.com",
+		},
+		{
+			name:            "Wildcard fully-qualified domain name",
+			hostname:        "*.example.com.",
+			delegatedDomain: "delegated.com",
+			expectDNSName:   "_acme-challenge.example.com",
+			expectTarget:    "_acme-challenge.example.com.delegated.com",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug that generates a CNAME with `*`.

Signed-off-by: naoki-take <naoki-take@cybozu.co.jp>