### PR TITLE
Update Kubernetes version to 1.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supported environments
 ----------------------
 
 - Kubernetes
-  - 1.34
+  - 1.35
 - Contour
   - 1.33
 - ExternalDNS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cybozu-go/contour-plus
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/cert-manager/cert-manager v1.20.0


### PR DESCRIPTION
contour-plus already supports k8s 1.35, so this PR bumps supported k8s version in README.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
