### PR TITLE
Refactor maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,8 @@ download-tools:
 download-crds:
 	curl -fsL -o $(CRD_DIR)/certmanager.yml -sLf https://github.com/jetstack/cert-manager/releases/download/$(call upstream-tag,$(CERT_MANAGER_VERSION))/cert-manager.crds.yaml
 	echo "$(CERTMANAGER_CRD_SHA256)  $(CRD_DIR)/certmanager.yml" | sha256sum --check
-	curl -fsL -o $(CRD_DIR)/dnsendpoint.yml -sLf https://github.com/kubernetes-sigs/external-dns/raw/$(call upstream-tag,$(EXTERNAL_DNS_VERSION))/config/crd/standard/dnsendpoints.externaldns.k8s.io.yaml
-	echo "$(EXTERNALDNS_CRD_SHA256)  $(CRD_DIR)/dnsendpoint.yml" | sha256sum --check
-	curl -fsL -o $(CRD_DIR)/httpproxy.yml -sLf https://github.com/projectcontour/contour/raw/$(call upstream-tag,$(CONTOUR_VERSION))/examples/contour/01-crds.yaml
-	echo "$(CONTOUR_CRD_SHA256)  $(CRD_DIR)/httpproxy.yml" | sha256sum --check
+	curl -fsL -o $(CRD_DIR)/dnsendpoint.yml -sLf https://github.com/kubernetes-sigs/external-dns/raw/$(EXTERNAL_DNS_COMMIT)/config/crd/standard/dnsendpoints.externaldns.k8s.io.yaml
+	curl -fsL -o $(CRD_DIR)/httpproxy.yml -sLf https://github.com/projectcontour/contour/raw/$(CONTOUR_COMMIT)/examples/contour/01-crds.yaml
 
 .PHONY: clean
 clean: ## Clean files

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,14 @@ update-cert-manager: ## Update cert-manager in go.mod to the pinned CERT_MANAGER
 	go get github.com/cert-manager/cert-manager@$(call upstream-tag,$(CERT_MANAGER_VERSION))
 	go mod tidy
 
+.PHONY: update-hashes
+update-hashes: ## Update commit hashes and file checksums for the pinned dependency versions
+	$(call update-commit,kubernetes-sigs/external-dns,$(call upstream-tag,$(EXTERNAL_DNS_VERSION)),EXTERNAL_DNS_COMMIT)
+	$(call update-commit,projectcontour/contour,$(call upstream-tag,$(CONTOUR_VERSION)),CONTOUR_COMMIT)
+	$(call update-commit,cert-manager/cert-manager,$(call upstream-tag,$(CERT_MANAGER_VERSION)),CERT_MANAGER_COMMIT)
+	$(call update-sha256,https://github.com/jetstack/cert-manager/releases/download/$(call upstream-tag,$(CERT_MANAGER_VERSION))/cert-manager.crds.yaml,CERTMANAGER_CRD_SHA256)
+	$(call update-sha256,https://github.com/jetstack/cert-manager/releases/download/$(call upstream-tag,$(CERT_MANAGER_VERSION))/cert-manager.yaml,CERTMANAGER_MANIFEST_SHA256)
+
 .PHONY: version
 version: login-gh ## Update dependent versions
 	$(call update-version,actions/checkout,ACTIONS_CHECKOUT_VERSION,1)
@@ -221,6 +229,20 @@ endef
 define update-version-ghcr
 	$(call get-latest-gh-package-tag,$1)
 	sed -i -e "s/$2 := .*/$2 := $(latest_tag)/g" Makefile.versions
+endef
+
+# usage: update-commit OWNER/REPO TAG VAR
+# resolve TAG to its commit SHA (the GitHub commits API dereferences annotated tags too) and record it in Makefile.versions
+define update-commit
+	COMMIT_SHA=$$(curl -sSf https://api.github.com/repos/$1/commits/$2 | jq -r '.sha'); \
+	sed -i -e "s/$3 := .*/$3 := $${COMMIT_SHA}/g" Makefile.versions
+endef
+
+# usage: update-sha256 URL VAR
+# compute the sha256 checksum of a downloaded file and record it in Makefile.versions
+define update-sha256
+	NEW_SHA256=$$(curl -sSLf $1 | sha256sum | cut -d' ' -f1); \
+	sed -i -e "s/$2 := .*/$2 := $${NEW_SHA256}/g" Makefile.versions
 endef
 
 # usage: update-aqua-package NAME (e.g. cli/cli, kubernetes-sigs/controller-tools/controller-gen)

--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,28 @@ version: login-gh ## Update dependent versions
 	$(call update-version-ghcr,etcd,ETCD_VERSION)
 	$(call update-version-ghcr,coredns,COREDNS_VERSION)
 
+	$(call get-latest-gh-release,aquaproj/aqua-registry)
+	$(YQ) -i '.registries[0].ref = "$(latest_gh)"' aqua.yaml
+	$(call update-aqua-package,cli/cli)
+	$(call update-aqua-package,helm/helm)
+	$(call update-aqua-package,kubernetes-sigs/kind)
+	$(call update-aqua-package,mikefarah/yq)
+	$(call update-aqua-package,kubernetes-sigs/controller-tools/controller-gen)
+	$(call update-aqua-package,kubernetes-sigs/controller-runtime/setup-envtest)
+	$(call update-aqua-package,dominikh/go-tools/staticcheck)
+	$(call update-aqua-package,golang/tools/goimports)
+
+	# kustomize follows the version bundled in the Argo CD image, since that's
+	# what renders our manifests for deployment
+	# https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile
+	$(call get-latest-gh-package-tag,argocd)
+	KUSTOMIZE_VERSION=$$(docker run ghcr.io/cybozu/argocd:$(latest_tag) kustomize version | cut -c2-); \
+	$(YQ) -i '(.packages[] | select(.name | test("^kubernetes-sigs/kustomize@"))).name = "kubernetes-sigs/kustomize@kustomize/v'"$$KUSTOMIZE_VERSION"'"' aqua.yaml
+
 	K8S_MINOR_VERSION="1."$$(go list -m -f '{{.Version}}' k8s.io/api | cut -d'.' -f2); \
 	NEW_VERSION=$$($(SETUP_ENVTEST) list | tr -s ' ' | cut -d' ' -f2 | fgrep $${K8S_MINOR_VERSION} | sort -V | tail -n 1 | cut -c2-); \
-	sed -i -e "s/ENVTEST_K8S_VERSION := .*/ENVTEST_K8S_VERSION := $${NEW_VERSION}/g" Makefile.versions
+	sed -i -e "s/ENVTEST_K8S_VERSION := .*/ENVTEST_K8S_VERSION := $${NEW_VERSION}/g" Makefile.versions; \
+	$(YQ) -i '(.packages[] | select(.name | test("^kubernetes/kubectl@"))).name = "kubernetes/kubectl@v'"$$NEW_VERSION"'"' aqua.yaml
 
 	# update kindest node version
 	K8S_MINOR_VERSION="1."$$(go list -m -f '{{.Version}}' k8s.io/api | cut -d'.' -f2); \
@@ -123,6 +142,9 @@ version: login-gh ## Update dependent versions
 	); \
 	echo "Updating kindest/node to $$NEW_KINDEST_TAG"; \
 	sed -i -e "s/KINDEST_NODE_VERSION := .*/KINDEST_NODE_VERSION := $${NEW_VERSION#v}/g" Makefile.versions
+
+	aqua update-checksum --prune
+	aqua install
 
 
 .PHONY: update-actions
@@ -197,6 +219,16 @@ endef
 define update-version-ghcr
 	$(call get-latest-gh-package-tag,$1)
 	sed -i -e "s/$2 := .*/$2 := $(latest_tag)/g" Makefile.versions
+endef
+
+# usage: update-aqua-package NAME (e.g. cli/cli, kubernetes-sigs/controller-tools/controller-gen)
+# bump an aqua.yaml package to its latest release
+# "aqua g" prints nothing when the pinned version is already the latest, so skip the update in that case
+define update-aqua-package
+	NEW_VERSION=$$(aqua g $1 2>/dev/null | tail -n 1 | sed -E 's/.*@//'); \
+	if [ -n "$$NEW_VERSION" ]; then \
+		$(YQ) -i '(.packages[] | select(.name | test("^$1@"))).name = "$1@'"$$NEW_VERSION"'"' aqua.yaml; \
+	fi
 endef
 
 # usage update-trusted-action OWNER/REPO VERSION

--- a/Makefile
+++ b/Makefile
@@ -84,14 +84,18 @@ logout-gh: ## Logout from GitHub
 	$(GH) auth logout
 
 .PHONY: update-contour
-update-contour: ## Update Contour and Kubernetes in go.mod
-	$(call get-latest-gh-package-tag,contour)
-	go get github.com/projectcontour/contour@$(call upstream-tag,$(latest_tag))
+update-contour: ## Update Contour and Kubernetes in go.mod to the pinned CONTOUR_VERSION
+	go get github.com/projectcontour/contour@$(call upstream-tag,$(CONTOUR_VERSION))
 	K8S_MINOR_VERSION="0."$$(go list -m -f '{{.Version}}' k8s.io/api | cut -d'.' -f2); \
 	K8S_PACKAGE_VERSION="$$(go list -m -versions k8s.io/api | tr ' ' '\n' | grep $${K8S_MINOR_VERSION} | sort -V | tail -n 1)"; \
 	go get k8s.io/api@$${K8S_PACKAGE_VERSION}; \
 	go get k8s.io/apimachinery@$${K8S_PACKAGE_VERSION}; \
 	go get k8s.io/client-go@$${K8S_PACKAGE_VERSION}; \
+	go mod tidy
+
+.PHONY: update-cert-manager
+update-cert-manager: ## Update cert-manager in go.mod to the pinned CERT_MANAGER_VERSION
+	go get github.com/cert-manager/cert-manager@$(call upstream-tag,$(CERT_MANAGER_VERSION))
 	go mod tidy
 
 .PHONY: version

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,6 @@ update-cert-manager: ## Update cert-manager in go.mod to the pinned CERT_MANAGER
 update-hashes: ## Update commit hashes and file checksums for the pinned dependency versions
 	$(call update-commit,kubernetes-sigs/external-dns,$(call upstream-tag,$(EXTERNAL_DNS_VERSION)),EXTERNAL_DNS_COMMIT)
 	$(call update-commit,projectcontour/contour,$(call upstream-tag,$(CONTOUR_VERSION)),CONTOUR_COMMIT)
-	$(call update-commit,cert-manager/cert-manager,$(call upstream-tag,$(CERT_MANAGER_VERSION)),CERT_MANAGER_COMMIT)
 	$(call update-sha256,https://github.com/jetstack/cert-manager/releases/download/$(call upstream-tag,$(CERT_MANAGER_VERSION))/cert-manager.crds.yaml,CERTMANAGER_CRD_SHA256)
 	$(call update-sha256,https://github.com/jetstack/cert-manager/releases/download/$(call upstream-tag,$(CERT_MANAGER_VERSION))/cert-manager.yaml,CERTMANAGER_MANIFEST_SHA256)
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ version: login-gh ## Update dependent versions
 	$(call update-version,actions/checkout,ACTIONS_CHECKOUT_VERSION,1)
 	$(call update-version,actions/create-release,ACTIONS_CREATE_RELEASE_VERSION,1)
 	$(call update-version,actions/setup-go,ACTIONS_SETUP_GO_VERSION,1)
+	$(call update-version,cybozu-go/golang-custom-analyzer,CUSTOM_CHECKER_VERSION)
 	$(call update-version-ghcr,cert-manager,CERT_MANAGER_VERSION)
 	$(call update-version-ghcr,contour,CONTOUR_VERSION)
 	$(call update-version-ghcr,external-dns,EXTERNAL_DNS_VERSION)

--- a/Makefile.versions
+++ b/Makefile.versions
@@ -12,14 +12,13 @@ CUSTOM_CHECKER_VERSION := 0.1.5
 # Commit SHAs for git-cloned external repositories (must be updated together with the version)
 EXTERNAL_DNS_COMMIT := 5c2787321948e391ac188584855a7339eb8dd5e1
 CONTOUR_COMMIT := 33278ce35c125f8f2338910c983587ac667f95e8
+# cert-manager's manifests are GitHub Release assets with no git-tree equivalent, so they
+# can't be fetched by commit hash like the above; kept for reference alongside CERT_MANAGER_VERSION.
+CERT_MANAGER_COMMIT := 0d2f215fe26ca2674758b5dfd780f04ac1dfde92
 
 # SHA256 checksums for downloaded files (must be updated together with the version)
 CERTMANAGER_CRD_SHA256 := 7326633f0f70514a71dc8eece2414c5f753b8d121e564d4c455f107f32a2defc
-EXTERNALDNS_CRD_SHA256 := 0dbd14aff7edbd9bffc0bb04068f53c6942c94e55567674844fea22fd5f9af9b
-CONTOUR_CRD_SHA256 := c02ed88146211c84edcafb718191f403ab35d8a9c6593bdc244338d20e8461b2
 CERTMANAGER_MANIFEST_SHA256 := a8e859afe65a630d80b2b7e7ef76b6c86c457cfe2bf194b1b3ed20cf6b23471f
-ETCD_YAML_SHA256 := 26d8a20e94007b3030f04fcbcddbe26b01eaab369b0a8a3c8b40c00001df365e
-COREDNS_VALUES_SHA256 := 195a33eb977f39f8280c0ef3146bf9c0fa67a19941e624d7df4e755096fd1b4e
 
 # Versions used only in e2e testing
 KINDEST_NODE_VERSION := 1.35.1

--- a/Makefile.versions
+++ b/Makefile.versions
@@ -12,9 +12,6 @@ CUSTOM_CHECKER_VERSION := 0.1.5
 # Commit SHAs for git-cloned external repositories (must be updated together with the version)
 EXTERNAL_DNS_COMMIT := 5c2787321948e391ac188584855a7339eb8dd5e1
 CONTOUR_COMMIT := 33278ce35c125f8f2338910c983587ac667f95e8
-# cert-manager's manifests are GitHub Release assets with no git-tree equivalent, so they
-# can't be fetched by commit hash like the above; kept for reference alongside CERT_MANAGER_VERSION.
-CERT_MANAGER_COMMIT := 0d2f215fe26ca2674758b5dfd780f04ac1dfde92
 
 # SHA256 checksums for downloaded files (must be updated together with the version)
 CERTMANAGER_CRD_SHA256 := 7326633f0f70514a71dc8eece2414c5f753b8d121e564d4c455f107f32a2defc

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -15,19 +15,26 @@
 4. Check `Makefile.versions` and `aqua.yaml` and revert some changes that you don't want now.
    If you revert an `aqua.yaml` change, re-run `aqua update-checksum --prune` to keep `aqua-checksums.json` in sync.
    Then run `make check-generate lint test` to confirm the tool versions still work.
-5. Update Contour and cert-manager versions in `go.mod` to the `CONTOUR_VERSION` and `CERT_MANAGER_VERSION` pinned in the previous steps.
+5. Update commit hashes and file checksums for the pinned dependency versions.
+   ```console
+   $ make update-hashes
+   ```
+   This resolves `EXTERNAL_DNS_COMMIT`, `CONTOUR_COMMIT`, and `CERT_MANAGER_COMMIT` to the commit each pinned version's
+   tag points to, and recomputes `CERTMANAGER_CRD_SHA256`/`CERTMANAGER_MANIFEST_SHA256` (cert-manager's manifests are
+   GitHub Release assets, so they still need a checksum rather than a commit hash; see the comment in `Makefile.versions`).
+6. Update Contour and cert-manager versions in `go.mod` to the `CONTOUR_VERSION` and `CERT_MANAGER_VERSION` pinned in the previous steps.
    `update-contour` also bumps `k8s.io/api`, `k8s.io/apimachinery`, and `k8s.io/client-go` to the latest patch of the Kubernetes minor version used by Contour.
    ```console
    $ make update-contour
    $ make update-cert-manager
    ```
-6. Update software versions using `make maintenance`.
+7. Update software versions using `make maintenance`.
    ```console
    $ make maintenance
    ```
-7. Update e2e test dependencies.
+8. Update e2e test dependencies.
    ```console
    $ cd e2e
    $ make update-dependencies
    ```
-8. Follow [RELEASE.md](/RELEASE.md) to update software version.
+9. Follow [RELEASE.md](/RELEASE.md) to update software version.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,14 +1,8 @@
 # Maintenance procedure
 
-1. Update Contour version in `go.mod`.
-   It also updates reference to Kubernetes in `go.mod`.
-   The Kubernetes version is the one used by Contour, but the latest patch version.
-   ```console
-   $ make update-contour
-   ```
-2. Update `go.mod` for the other dependencies.
-3. Update Go & Ubuntu versions if needed.
-4. Check for new software versions using `make version`. You may be prompted to login to github.com.
+1. Update `go.mod` for dependencies other than Contour and cert-manager.
+2. Update Go & Ubuntu versions if needed.
+3. Check for new software versions using `make version`. You may be prompted to login to github.com.
    ```console
    $ make version
    ```
@@ -18,9 +12,15 @@
    and regenerates `aqua-checksums.json` accordingly. Note two exceptions that aren't bumped to their own latest release:
    - `kustomize` is pinned to the version bundled in the Argo CD image, since that's what renders our manifests for deployment.
    - `kubectl` is pinned to the same version as `ENVTEST_K8S_VERSION`, to match the Kubernetes version used by envtest.
-5. Check `Makefile.versions` and `aqua.yaml` and revert some changes that you don't want now.
+4. Check `Makefile.versions` and `aqua.yaml` and revert some changes that you don't want now.
    If you revert an `aqua.yaml` change, re-run `aqua update-checksum --prune` to keep `aqua-checksums.json` in sync.
    Then run `make check-generate lint test` to confirm the tool versions still work.
+5. Update Contour and cert-manager versions in `go.mod` to the `CONTOUR_VERSION` and `CERT_MANAGER_VERSION` pinned in the previous steps.
+   `update-contour` also bumps `k8s.io/api`, `k8s.io/apimachinery`, and `k8s.io/client-go` to the latest patch of the Kubernetes minor version used by Contour.
+   ```console
+   $ make update-contour
+   $ make update-cert-manager
+   ```
 6. Update software versions using `make maintenance`.
    ```console
    $ make maintenance

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -8,25 +8,26 @@
    ```
 2. Update `go.mod` for the other dependencies.
 3. Update Go & Ubuntu versions if needed.
-4. Update tool versions managed by [aqua](https://aquaproj.github.io/) (`gh`, `yq`, `kubectl`, `kustomize`, `helm`, `kind`, `controller-gen`, `setup-envtest`, `staticcheck`, `goimports`).
-   Edit the `packages[].name` entries in `aqua.yaml`, and bump the registry `ref` if a newer [aqua-registry release](https://github.com/aquaproj/aqua-registry/releases) is available.
-   Then regenerate `aqua-checksums.json`, pruning entries for versions that are no longer referenced.
-   ```console
-   $ aqua update-checksum --prune
-   ```
-   Run `make check-generate lint test` to confirm the new tool versions still work.
-5. Check for new software versions using `make version`. You may be prompted to login to github.com.
+4. Check for new software versions using `make version`. You may be prompted to login to github.com.
    ```console
    $ make version
    ```
-6. Check `Makefile.versions` and revert some changes that you don't want now.
-7. Update software versions using `make maintenance`.
+   This also updates the tools managed by [aqua](https://aquaproj.github.io/) in `aqua.yaml`
+   (`gh`, `yq`, `kubectl`, `kustomize`, `helm`, `kind`, `controller-gen`, `setup-envtest`, `staticcheck`, `goimports`),
+   bumps the registry `ref` to the latest [aqua-registry release](https://github.com/aquaproj/aqua-registry/releases),
+   and regenerates `aqua-checksums.json` accordingly. Note two exceptions that aren't bumped to their own latest release:
+   - `kustomize` is pinned to the version bundled in the Argo CD image, since that's what renders our manifests for deployment.
+   - `kubectl` is pinned to the same version as `ENVTEST_K8S_VERSION`, to match the Kubernetes version used by envtest.
+5. Check `Makefile.versions` and `aqua.yaml` and revert some changes that you don't want now.
+   If you revert an `aqua.yaml` change, re-run `aqua update-checksum --prune` to keep `aqua-checksums.json` in sync.
+   Then run `make check-generate lint test` to confirm the tool versions still work.
+6. Update software versions using `make maintenance`.
    ```console
    $ make maintenance
    ```
-8. Update e2e test dependencies.
+7. Update e2e test dependencies.
    ```console
    $ cd e2e
    $ make update-dependencies
    ```
-9. Follow [RELEASE.md](/RELEASE.md) to update software version.
+8. Follow [RELEASE.md](/RELEASE.md) to update software version.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -19,9 +19,9 @@
    ```console
    $ make update-hashes
    ```
-   This resolves `EXTERNAL_DNS_COMMIT`, `CONTOUR_COMMIT`, and `CERT_MANAGER_COMMIT` to the commit each pinned version's
-   tag points to, and recomputes `CERTMANAGER_CRD_SHA256`/`CERTMANAGER_MANIFEST_SHA256` (cert-manager's manifests are
-   GitHub Release assets, so they still need a checksum rather than a commit hash; see the comment in `Makefile.versions`).
+   This resolves `EXTERNAL_DNS_COMMIT` and `CONTOUR_COMMIT` to the commit each pinned version's tag points to, and
+   recomputes `CERTMANAGER_CRD_SHA256`/`CERTMANAGER_MANIFEST_SHA256` (cert-manager's manifests are GitHub Release
+   assets with no git-tree equivalent, so they're pinned by checksum instead of commit hash).
 6. Update Contour and cert-manager versions in `go.mod` to the `CONTOUR_VERSION` and `CERT_MANAGER_VERSION` pinned in the previous steps.
    `update-contour` also bumps `k8s.io/api`, `k8s.io/apimachinery`, and `k8s.io/client-go` to the latest patch of the Kubernetes minor version used by Contour.
    ```console

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -26,10 +26,8 @@ install-cert-manager:
 .PHONY: update-coredns-manifests
 update-coredns-manifests:
 	mkdir -p testdata/coredns/upstream
-	curl -sSLf -o testdata/coredns/upstream/etcd.yaml https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/$(call upstream-tag,$(EXTERNAL_DNS_VERSION))/docs/snippets/tutorials/coredns/etcd.yaml
-	echo "$(ETCD_YAML_SHA256)  testdata/coredns/upstream/etcd.yaml" | sha256sum --check
-	curl -sSLf -o testdata/coredns/upstream/values-coredns.yaml https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/$(call upstream-tag,$(EXTERNAL_DNS_VERSION))/docs/snippets/tutorials/coredns/values-coredns.yaml
-	echo "$(COREDNS_VALUES_SHA256)  testdata/coredns/upstream/values-coredns.yaml" | sha256sum --check
+	curl -sSLf -o testdata/coredns/upstream/etcd.yaml https://raw.githubusercontent.com/kubernetes-sigs/external-dns/$(EXTERNAL_DNS_COMMIT)/docs/snippets/tutorials/coredns/etcd.yaml
+	curl -sSLf -o testdata/coredns/upstream/values-coredns.yaml https://raw.githubusercontent.com/kubernetes-sigs/external-dns/$(EXTERNAL_DNS_COMMIT)/docs/snippets/tutorials/coredns/values-coredns.yaml
 	# replace etcd resource namespace
 	$(YQ) -i 'select(.metadata.namespace) | .metadata.namespace = "external-dns"' testdata/coredns/upstream/etcd.yaml
 	# replace binary path with that of cybozu build


### PR DESCRIPTION
## Summary of changes

- Automate aqua tool version bumps (`gh`, `helm`, `kind`, `yq`, `controller-gen`, `setup-envtest`, `staticcheck`, `goimports`, registry `ref`) in `make version`; restore `kustomize`↔Argo-CD and `kubectl`↔`ENVTEST_K8S_VERSION` pinning dropped in the earlier aqua migration.
- Drop redundant SHA256 checks for files that can instead be pinned by commit hash (external-dns/contour CRDs and coredns manifests); add `CERT_MANAGER_COMMIT` for consistency (cert-manager's manifests stay checksum-verified since they're release assets, not in-tree files).
- Add `update-contour`/`update-cert-manager` targets to bump `go.mod` to the pinned `Makefile.versions` values.
- Add `update-hashes` target to refresh commit hashes and cert-manager checksums.
- Fix `CUSTOM_CHECKER_VERSION`, the one version `make version` never touched.
- Update `docs/maintenance.md` accordingly.
