### PR TITLE
reduce TTL for ACME delegation record

### DIFF
--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -779,7 +779,7 @@ func makeDelegationEndpoint(hostname, delegatedDomain string) []map[string]any {
 			"dnsName":    "_acme-challenge." + fqdn,
 			"targets":    []string{"_acme-challenge." + fqdn + "." + delegatedDomain},
 			"recordType": "CNAME",
-			"recordTTL":  3600,
+			"recordTTL":  60,
 		},
 	}
 }


### PR DESCRIPTION
Currently, delegation records are created with a TTL of one hour. With bad timing, `cert-manager` may not see the CNAME delegation in time when attempting to create the certificate, and attempts to solve the DNS-01 challenge in a zone for which it does not have write access, resulting in a challenge failure. Since the TTL is too high, this can lead to certificate issuance delays of up to 1h.

A TTL of 1m should be reasonable in this case to reduce the time lag until `cert-manager` picks up the correct challenge target. Since the CNAME delegation record is not intended to be used outside of `cert-manager` certificate issuance/renewals, a low TTL does not carry much negative impact.