### PR TITLE
feat: add support for tuning TTLs on DNS records

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,8 +52,8 @@ func init() {
 	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
 	fs.Duration("certificate-apply-retry-base-delay", controllers.DefaultRetryBaseDelay, "Base delay for certificate apply exponential backoff retry")
 	fs.Duration("certificate-apply-retry-max-delay", controllers.DefaultRetryMaxDelay, "Maximum delay for certificate apply exponential backoff retry")
-	fs.Uint64("default-dns-ttl", controllers.DefaultDNSTTL, "Default TTL value for DNSEndpoint A records")
-	fs.Uint64("default-dns-delegation-ttl", controllers.DefaultDNSDelegationTTL, "Default TTL value for DNSEndpoint CNAME delgation records")
+	fs.Int32("default-dns-ttl", controllers.DefaultDNSTTL, "Default TTL value for DNSEndpoint A records")
+	fs.Int32("default-dns-delegation-ttl", controllers.DefaultDNSDelegationTTL, "Default TTL value for DNSEndpoint CNAME delgation records")
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,8 @@ func init() {
 	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
 	fs.Duration("certificate-apply-retry-base-delay", controllers.DefaultRetryBaseDelay, "Base delay for certificate apply exponential backoff retry")
 	fs.Duration("certificate-apply-retry-max-delay", controllers.DefaultRetryMaxDelay, "Maximum delay for certificate apply exponential backoff retry")
+	fs.Uint64("default-dns-ttl", controllers.DefaultDNSTTL, "Default TTL value for DNSEndpoint A records")
+	fs.Uint64("default-dns-delegation-ttl", controllers.DefaultDNSDelegationTTL, "Default TTL value for DNSEndpoint CNAME delgation records")
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,6 +78,10 @@ func run() error {
 
 	opts.AllowedDNSNamespaces = viper.GetStringSlice("allowed-dns-namespaces")
 	opts.AllowedIssuerNamespaces = viper.GetStringSlice("allowed-issuer-namespaces")
+
+	opts.DefaultDNSTTL = viper.GetUint64("default-dns-ttl")
+	opts.DefaultDNSDelegationTTL = viper.GetUint64("default-dns-delegation-ttl")
+
 	opts.CertificateApplyLimit = viper.GetFloat64("certificate-apply-limit")
 	if opts.CertificateApplyLimit < 0 {
 		return errors.New("certificate-apply-limit must be greater than or equal to 0")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -80,7 +80,13 @@ func run() error {
 	opts.AllowedIssuerNamespaces = viper.GetStringSlice("allowed-issuer-namespaces")
 
 	opts.DefaultDNSTTL = viper.GetInt32("default-dns-ttl")
+	if opts.DefaultDNSTTL < 0 {
+		return errors.New("default-dns-ttl must be a positive integer")
+	}
 	opts.DefaultDNSDelegationTTL = viper.GetInt32("default-dns-delegation-ttl")
+	if opts.DefaultDNSDelegationTTL < 0 {
+		return errors.New("default-dns-delegation-ttl must be a positive integer")
+	}
 
 	opts.CertificateApplyLimit = viper.GetFloat64("certificate-apply-limit")
 	if opts.CertificateApplyLimit < 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -79,8 +79,8 @@ func run() error {
 	opts.AllowedDNSNamespaces = viper.GetStringSlice("allowed-dns-namespaces")
 	opts.AllowedIssuerNamespaces = viper.GetStringSlice("allowed-issuer-namespaces")
 
-	opts.DefaultDNSTTL = viper.GetUint64("default-dns-ttl")
-	opts.DefaultDNSDelegationTTL = viper.GetUint64("default-dns-delegation-ttl")
+	opts.DefaultDNSTTL = viper.GetInt32("default-dns-ttl")
+	opts.DefaultDNSDelegationTTL = viper.GetInt32("default-dns-delegation-ttl")
 
 	opts.CertificateApplyLimit = viper.GetFloat64("certificate-apply-limit")
 	if opts.CertificateApplyLimit < 0 {

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -18,3 +18,9 @@ const (
 	usageKeyEncipherment  = "key encipherment"
 	usageServerAuth       = "server auth"
 )
+
+// Constants for TTL values
+const (
+	DefaultDNSTTL           = 3600
+	DefaultDNSDelegationTTL = 60
+)

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -743,7 +743,7 @@ func (r *HTTPProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-func makeEndpoints(hostname string, ips []net.IP, ttl uint64) []map[string]any {
+func makeEndpoints(hostname string, ips []net.IP, ttl int32) []map[string]any {
 	ipv4Targets, ipv6Targets := ipsToTargets(ips)
 	var endpoints []map[string]any
 	if len(ipv4Targets) != 0 {
@@ -778,7 +778,7 @@ func ipsToTargets(ips []net.IP) ([]string, []string) {
 	return ipv4Targets, ipv6Targets
 }
 
-func makeDelegationEndpoint(hostname, delegatedDomain string, ttl uint64) []map[string]any {
+func makeDelegationEndpoint(hostname, delegatedDomain string, ttl int32) []map[string]any {
 	fqdn := strings.Trim(hostname, ".")
 	fqdn = strings.TrimPrefix(fqdn, "*.")
 	return []map[string]any{
@@ -818,13 +818,13 @@ func getDNSEndpointName(r *HTTPProxyReconciler, hp *projectcontourv1.HTTPProxy) 
 	return r.Prefix + hp.Namespace + "-" + hp.Name
 }
 
-func getTTL(hp *projectcontourv1.HTTPProxy, annotationKey string, defaultTTL uint64) uint64 {
+func getTTL(hp *projectcontourv1.HTTPProxy, annotationKey string, defaultTTL int32) int32 {
 	if value, ok := hp.Annotations[annotationKey]; ok {
-		parsedTTL, err := strconv.ParseUint(value, 10, 64)
-		if err != nil {
+		parsedTTL, err := strconv.ParseInt(value, 10, 32)
+		if err != nil || parsedTTL < 0 {
 			return defaultTTL
 		}
-		return parsedTTL
+		return int32(parsedTTL)
 	}
 	return defaultTTL
 }

--- a/controllers/httpproxy_controller.go
+++ b/controllers/httpproxy_controller.go
@@ -44,6 +44,8 @@ const (
 	dnsNamespaceAnnotation            = "contour-plus.cybozu.com/dns-namespace"
 	issuerNamespaceAnnotation         = "contour-plus.cybozu.com/issuer-namespace"
 	ownerAnnotation                   = "contour-plus.cybozu.com/owned-by"
+	dnsTTLAnnotation                  = "contour-plus.cybozu.com/dns-ttl"
+	dnsDelegationTTLAnnotation        = "contour-plus.cybozu.com/dns-delegation-ttl"
 	finalizerName                     = "contour-plus.cybozu.com/finalizer"
 )
 
@@ -166,6 +168,7 @@ func (r *HTTPProxyReconciler) reconcileDNSEndpoint(ctx context.Context, hp *proj
 	if hp.Spec.VirtualHost == nil {
 		return nil
 	}
+
 	fqdn := hp.Spec.VirtualHost.Fqdn
 	if len(fqdn) == 0 {
 		return nil
@@ -198,6 +201,8 @@ func (r *HTTPProxyReconciler) reconcileDNSEndpoint(ctx context.Context, hp *proj
 		targetNamespace = ns
 	}
 
+	ttl := getTTL(hp, dnsTTLAnnotation, r.DefaultDNSTTL)
+
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(externalDNSGroupVersion.WithKind(DNSEndpointKind))
 	obj.SetName(dnsEndpointName)
@@ -205,7 +210,7 @@ func (r *HTTPProxyReconciler) reconcileDNSEndpoint(ctx context.Context, hp *proj
 	obj.SetAnnotations(r.generateObjectAnnotations(hp))
 	obj.SetLabels(r.generateObjectLabels(hp))
 	obj.UnstructuredContent()["spec"] = map[string]any{
-		"endpoints": makeEndpoints(fqdn, serviceIPs),
+		"endpoints": makeEndpoints(fqdn, serviceIPs, ttl),
 	}
 	err = r.trackResourceOwnership(hp, obj)
 	if err != nil {
@@ -247,6 +252,8 @@ func (r *HTTPProxyReconciler) reconcileDelegationDNSEndpoint(ctx context.Context
 		return nil
 	}
 
+	ttl := getTTL(hp, dnsDelegationTTLAnnotation, r.DefaultDNSDelegationTTL)
+
 	dnsEndpointName := getDNSEndpointName(r, hp)
 	targetNamespace := hp.Namespace
 	if ns, ok := hp.Annotations[dnsNamespaceAnnotation]; ok && slices.Contains(r.AllowedDNSNamespaces, ns) {
@@ -260,7 +267,7 @@ func (r *HTTPProxyReconciler) reconcileDelegationDNSEndpoint(ctx context.Context
 	obj.SetAnnotations(r.generateObjectAnnotations(hp))
 	obj.SetLabels(r.generateObjectLabels(hp))
 	obj.UnstructuredContent()["spec"] = map[string]any{
-		"endpoints": makeDelegationEndpoint(fqdn, delegatedDomain),
+		"endpoints": makeDelegationEndpoint(fqdn, delegatedDomain, ttl),
 	}
 
 	if err := r.trackResourceOwnership(hp, obj); err != nil {
@@ -736,7 +743,7 @@ func (r *HTTPProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-func makeEndpoints(hostname string, ips []net.IP) []map[string]any {
+func makeEndpoints(hostname string, ips []net.IP, ttl uint64) []map[string]any {
 	ipv4Targets, ipv6Targets := ipsToTargets(ips)
 	var endpoints []map[string]any
 	if len(ipv4Targets) != 0 {
@@ -744,7 +751,7 @@ func makeEndpoints(hostname string, ips []net.IP) []map[string]any {
 			"dnsName":    hostname,
 			"targets":    ipv4Targets,
 			"recordType": "A",
-			"recordTTL":  3600,
+			"recordTTL":  ttl,
 		})
 	}
 	if len(ipv6Targets) != 0 {
@@ -752,7 +759,7 @@ func makeEndpoints(hostname string, ips []net.IP) []map[string]any {
 			"dnsName":    hostname,
 			"targets":    ipv6Targets,
 			"recordType": "AAAA",
-			"recordTTL":  3600,
+			"recordTTL":  ttl,
 		})
 	}
 	return endpoints
@@ -771,7 +778,7 @@ func ipsToTargets(ips []net.IP) ([]string, []string) {
 	return ipv4Targets, ipv6Targets
 }
 
-func makeDelegationEndpoint(hostname, delegatedDomain string) []map[string]any {
+func makeDelegationEndpoint(hostname, delegatedDomain string, ttl uint64) []map[string]any {
 	fqdn := strings.Trim(hostname, ".")
 	fqdn = strings.TrimPrefix(fqdn, "*.")
 	return []map[string]any{
@@ -779,7 +786,7 @@ func makeDelegationEndpoint(hostname, delegatedDomain string) []map[string]any {
 			"dnsName":    "_acme-challenge." + fqdn,
 			"targets":    []string{"_acme-challenge." + fqdn + "." + delegatedDomain},
 			"recordType": "CNAME",
-			"recordTTL":  60,
+			"recordTTL":  ttl,
 		},
 	}
 }
@@ -809,4 +816,15 @@ func getDNSEndpointName(r *HTTPProxyReconciler, hp *projectcontourv1.HTTPProxy) 
 		return r.Prefix + hp.Name
 	}
 	return r.Prefix + hp.Namespace + "-" + hp.Name
+}
+
+func getTTL(hp *projectcontourv1.HTTPProxy, annotationKey string, defaultTTL uint64) uint64 {
+	if value, ok := hp.Annotations[annotationKey]; ok {
+		parsedTTL, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return defaultTTL
+		}
+		return parsedTTL
+	}
+	return defaultTTL
 }

--- a/controllers/httpproxy_controller_test.go
+++ b/controllers/httpproxy_controller_test.go
@@ -1666,6 +1666,8 @@ func TestMakeDelegationEndpoint(t *testing.T) {
 		delegatedDomain string
 		expectDNSName   string
 		expectTarget    string
+		ttl             uint64
+		expectTTL       uint64
 	}{
 		{
 			name:            "Hostname without trailing dot",
@@ -1695,10 +1697,19 @@ func TestMakeDelegationEndpoint(t *testing.T) {
 			expectDNSName:   "_acme-challenge.example.com",
 			expectTarget:    "_acme-challenge.example.com.delegated.com",
 		},
+		{
+			name:            "Custom TTL",
+			hostname:        "example.com",
+			delegatedDomain: "delegated.com",
+			expectDNSName:   "_acme-challenge.example.com",
+			expectTarget:    "_acme-challenge.example.com.delegated.com",
+			ttl:             100,
+			expectTTL:       100,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actuals := makeDelegationEndpoint(tc.hostname, tc.delegatedDomain)
+			actuals := makeDelegationEndpoint(tc.hostname, tc.delegatedDomain, tc.ttl)
 			if len(actuals) != 1 {
 				t.Errorf("HTTPProxyReconciler.makeDelegationEndpoint() = %v, want 1 item", len(actuals))
 			}
@@ -1712,6 +1723,9 @@ func TestMakeDelegationEndpoint(t *testing.T) {
 			}
 			if actualTargets[0] != tc.expectTarget {
 				t.Errorf("HTTPProxyReconciler.makeDelegationEndpoint() target = %v, want %v", actualTargets[0], tc.expectTarget)
+			}
+			if actual["recordTTL"] != tc.expectTTL {
+				t.Errorf("HTTPProxyReconciler.makeDelegationEndpoint() ttl = %v, want %v", actual["recordTTL"], tc.expectTTL)
 			}
 		})
 	}
@@ -1865,6 +1879,59 @@ func TestGetDNSEndpointName(t *testing.T) {
 			actual := getDNSEndpointName(tc.reconciler, tc.proxy)
 			if actual != tc.expectName {
 				t.Errorf("HTTPProxyReconciler.getDNSEndpointName() = %v, want %v", actual, tc.expectName)
+			}
+		})
+	}
+}
+
+func TestGetTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxy     *projectcontourv1.HTTPProxy
+		expectTTL uint64
+	}{
+		{
+			name: "Default TTL",
+			proxy: &projectcontourv1.HTTPProxy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			expectTTL: DefaultDNSTTL,
+		},
+		{
+			name: "Custom TTL",
+			proxy: &projectcontourv1.HTTPProxy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						dnsTTLAnnotation: "600",
+					},
+				},
+			},
+			expectTTL: 600,
+		},
+		{
+			name: "Invalid custom TTL",
+			proxy: &projectcontourv1.HTTPProxy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						dnsTTLAnnotation: "-600",
+					},
+				},
+			},
+			expectTTL: DefaultDNSTTL,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getTTL(tc.proxy, dnsTTLAnnotation, DefaultDNSTTL)
+			if actual != tc.expectTTL {
+				t.Errorf("HTTPProxyReconciler.getTTL() = %v, want %v", actual, tc.expectTTL)
 			}
 		})
 	}

--- a/controllers/httpproxy_controller_test.go
+++ b/controllers/httpproxy_controller_test.go
@@ -1666,8 +1666,8 @@ func TestMakeDelegationEndpoint(t *testing.T) {
 		delegatedDomain string
 		expectDNSName   string
 		expectTarget    string
-		ttl             uint64
-		expectTTL       uint64
+		ttl             int32
+		expectTTL       int32
 	}{
 		{
 			name:            "Hostname without trailing dot",
@@ -1888,7 +1888,7 @@ func TestGetTTL(t *testing.T) {
 	tests := []struct {
 		name      string
 		proxy     *projectcontourv1.HTTPProxy
-		expectTTL uint64
+		expectTTL int32
 	}{
 		{
 			name: "Default TTL",
@@ -1921,6 +1921,19 @@ func TestGetTTL(t *testing.T) {
 					Namespace: "bar",
 					Annotations: map[string]string{
 						dnsTTLAnnotation: "-600",
+					},
+				},
+			},
+			expectTTL: DefaultDNSTTL,
+		},
+		{
+			name: "Overflowing custom TTL",
+			proxy: &projectcontourv1.HTTPProxy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						dnsTTLAnnotation: "2147483648",
 					},
 				},
 			},

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -34,6 +34,8 @@ type ReconcilerOptions struct {
 	CertificateApplyLimit          float64
 	CertificateApplyRetryBaseDelay time.Duration
 	CertificateApplyRetryMaxDelay  time.Duration
+	DefaultDNSTTL                  uint64
+	DefaultDNSDelegationTTL        uint64
 }
 
 // SetupScheme initializes a schema

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -34,8 +34,8 @@ type ReconcilerOptions struct {
 	CertificateApplyLimit          float64
 	CertificateApplyRetryBaseDelay time.Duration
 	CertificateApplyRetryMaxDelay  time.Duration
-	DefaultDNSTTL                  uint64
-	DefaultDNSDelegationTTL        uint64
+	DefaultDNSTTL                  int32
+	DefaultDNSDelegationTTL        int32
 }
 
 // SetupScheme initializes a schema

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,8 @@ If both is specified, command-line flags take precedence.
 | `propagated-labels     `  | `CP_PROPAGATED_LABELS`       | ""                | Comma-separated list of label keys that should be propagated to the resources contour-plus generates      |
 | `allowed-dns-namespaces`    | `CP_ALLOWED_DNS_NAMESPACES`    | ""                | List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed |
 | `allowed-issuer-namespaces` | `CP_ALLOWED_ISSUER_NAMESPACES` | ""                | List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed |
+| `default-dns-ttl`                   | `CP_DEFAULT_DNS_TTL`            | 3600     | Default TTL value for DNSEndpoint A records |
+| `default-dns-delegation-ttl`        | `CP_DEFAULT_DNS_DELEGATION_TTL` | 60       | Default TTL value for DNSEndpoint CNAME delgation records |
 
 By default, contour-plus creates [DNSEndpoint][] when `spec.virtualhost.fqdn` of an HTTPProxy is not empty,
 and creates [Certificate][] when `spec.virtualhost.tls.secretName` is not empty and not namespaced.
@@ -140,6 +142,8 @@ contour-plus interprets following annotations for HTTPProxy.
 - `contour-plus.cybozu.com/delegated-domain: "acme.example.com"` - With this, contour-plus generates a [DNSEndpoint][] to create a CNAME record pointing to the delegation domain for use when performing DNS-01 DCV during the Certificate creation.
 - `contour-plus.cybozu.com/dns-namespace` - The namespace in which contour-plus will place a DNSEndpoint.
 - `contour-plus.cybozu.com/issuer-namespace` - The namespace in which contour-plus will place a Certificate.
+- `contour-plus.cybozu.com/dns-ttl` - The TTL for the DNSEndpoint A record.
+- `contour-plus.cybozu.com/dns-delegation-ttl` - The TTL for the DNSEndpoint CNAME delegation record.
 
 If both of `cert-manager.io/issuer` and `cert-manager.io/cluster-issuer` exist, `cluster-issuer` takes precedence.
 


### PR DESCRIPTION
Currently, TTLs for DNS records are hardcoded to 3600s for A records, and 60s for CNAME delegation records since #151. While these are sensible defaults, the fundamental issue is that some environments or operational requirements may necessitate more flexibility in how TTLs are defined. For instance, for frequently accessed, long-lived endpoints, it may make more sense to specify a longer TTL for improved efficiency, whereas lowering TTLs would be warranted in a migration scenario.

This PR adds tunables for user-specified TTLs, enabling the override of previously hardcoded values, now treated as defaults.