### PR TITLE
chore: refactor ReconcilerOptions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,26 +34,10 @@ func init() {
 
 	fs := rootCmd.Flags()
 	fs.String("metrics-addr", ":8180", "Bind address for the metrics endpoint")
-	fs.StringSlice("crds", []string{controllers.DNSEndpointKind, controllers.CertificateKind}, "List of CRD names to be created")
-	fs.String("name-prefix", "", "Prefix of CRD names to be created")
-	fs.String("service-name", "", "NamespacedName of the Contour LoadBalancer Service")
-	fs.String("default-issuer-name", "", "Issuer name used by default")
-	fs.String("default-issuer-kind", controllers.ClusterIssuerKind, "Issuer kind used by default")
-	fs.String("default-delegated-domain", "", "Delegated domain used by default")
-	fs.StringSlice("allowed-delegated-domains", []string{}, "List of allowed delegated domains")
-	fs.Bool("allow-custom-delegations", false, "Allow custom delegated domains via annotations")
-	fs.Uint("csr-revision-limit", 0, "Maximum number of CertificateRequest revisions to keep")
-	fs.String("ingress-class-name", "", "Ingress class name that watched by Contour Plus. If not specified, then all classes are watched")
 	fs.Bool("leader-election", true, "Enable/disable leader election")
-	fs.StringSlice("propagated-annotations", []string{}, "List of annotation keys to be propagated from HTTPProxy to generated resources")
-	fs.StringSlice("propagated-labels", []string{}, "List of label keys to be propagated from HTTPProxy to generated resources")
-	fs.StringSlice("allowed-dns-namespaces", []string{}, "List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed")
-	fs.StringSlice("allowed-issuer-namespaces", []string{}, "List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed")
-	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
-	fs.Duration("certificate-apply-retry-base-delay", controllers.DefaultRetryBaseDelay, "Base delay for certificate apply exponential backoff retry")
-	fs.Duration("certificate-apply-retry-max-delay", controllers.DefaultRetryMaxDelay, "Maximum delay for certificate apply exponential backoff retry")
-	fs.Int32("default-dns-ttl", controllers.DefaultDNSTTL, "Default TTL value for DNSEndpoint A records")
-	fs.Int32("default-dns-delegation-ttl", controllers.DefaultDNSDelegationTTL, "Default TTL value for DNSEndpoint CNAME delgation records")
+
+	controllers.BindFlags(fs)
+
 	if err := viper.BindPFlags(fs); err != nil {
 		panic(err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"os"
-	"strings"
 
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -27,82 +24,17 @@ func init() {
 func run() error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
-	opts := controllers.ReconcilerOptions{
-		Prefix:            viper.GetString("name-prefix"),
-		DefaultIssuerName: viper.GetString("default-issuer-name"),
+	var opts controllers.ReconcilerOptions
+	if err := viper.Unmarshal(&opts); err != nil {
+		return err
 	}
 
-	crds := viper.GetStringSlice("crds")
-	if len(crds) == 0 {
-		return errors.New("at least one service need to be enabled")
-	}
-	for _, crd := range crds {
-		switch crd {
-		case controllers.DNSEndpointKind:
-			opts.CreateDNSEndpoint = true
-		case controllers.CertificateKind:
-			opts.CreateCertificate = true
-		default:
-			return errors.New("unsupported CRD: " + crd)
-		}
+	if err := opts.Finalize(); err != nil {
+		return err
 	}
 
-	serviceName := viper.GetString("service-name")
-	nsname := strings.Split(serviceName, "/")
-	if len(nsname) != 2 || nsname[0] == "" || nsname[1] == "" {
-		return errors.New("service-name should be valid string as namespaced-name")
-	}
-	opts.ServiceKey = client.ObjectKey{
-		Namespace: nsname[0],
-		Name:      nsname[1],
-	}
-
-	defaultIssuerKind := viper.GetString("default-issuer-kind")
-	switch defaultIssuerKind {
-	case controllers.IssuerKind, controllers.ClusterIssuerKind:
-	default:
-		return errors.New("unsupported Issuer kind: " + defaultIssuerKind)
-	}
-	opts.DefaultIssuerKind = defaultIssuerKind
-
-	opts.IngressClassName = viper.GetString("ingress-class-name")
-
-	opts.CSRRevisionLimit = viper.GetUint("csr-revision-limit")
-
-	opts.PropagatedAnnotations = viper.GetStringSlice("propagated-annotations")
-	opts.PropagatedLabels = viper.GetStringSlice("propagated-labels")
-
-	opts.DefaultDelegatedDomain = viper.GetString("default-delegated-domain")
-	opts.AllowCustomDelegations = viper.GetBool("allow-custom-delegations")
-	opts.AllowedDelegatedDomains = viper.GetStringSlice("allowed-delegated-domains")
-
-	opts.AllowedDNSNamespaces = viper.GetStringSlice("allowed-dns-namespaces")
-	opts.AllowedIssuerNamespaces = viper.GetStringSlice("allowed-issuer-namespaces")
-
-	opts.DefaultDNSTTL = viper.GetInt32("default-dns-ttl")
-	if opts.DefaultDNSTTL < 0 {
-		return errors.New("default-dns-ttl must be a positive integer")
-	}
-	opts.DefaultDNSDelegationTTL = viper.GetInt32("default-dns-delegation-ttl")
-	if opts.DefaultDNSDelegationTTL < 0 {
-		return errors.New("default-dns-delegation-ttl must be a positive integer")
-	}
-
-	opts.CertificateApplyLimit = viper.GetFloat64("certificate-apply-limit")
-	if opts.CertificateApplyLimit < 0 {
-		return errors.New("certificate-apply-limit must be greater than or equal to 0")
-	}
-
-	opts.CertificateApplyRetryBaseDelay = viper.GetDuration("certificate-apply-retry-base-delay")
-	if opts.CertificateApplyRetryBaseDelay <= 0 {
-		return errors.New("certificate-apply-retry-base-delay must be greater than 0")
-	}
-	opts.CertificateApplyRetryMaxDelay = viper.GetDuration("certificate-apply-retry-max-delay")
-	if opts.CertificateApplyRetryMaxDelay <= 0 {
-		return errors.New("certificate-apply-retry-max-delay must be greater than 0")
-	}
-	if opts.CertificateApplyRetryMaxDelay < opts.CertificateApplyRetryBaseDelay {
-		return errors.New("certificate-apply-retry-max-delay must be greater than or equal to certificate-apply-retry-base-delay")
+	if err := opts.Validate(); err != nil {
+		return err
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -1,10 +1,13 @@
 package controllers
 
 import (
+	"errors"
+	"strings"
 	"time"
 
 	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -16,26 +19,105 @@ import (
 
 // ReconcilerOptions is a set of options for reconcilers
 type ReconcilerOptions struct {
-	ServiceKey                     client.ObjectKey
-	Prefix                         string
-	DefaultIssuerName              string
-	DefaultIssuerKind              string
-	DefaultDelegatedDomain         string
-	AllowedDelegatedDomains        []string
-	AllowCustomDelegations         bool
-	CSRRevisionLimit               uint
-	CreateDNSEndpoint              bool
-	CreateCertificate              bool
-	IngressClassName               string
-	PropagatedAnnotations          []string
-	PropagatedLabels               []string
-	AllowedDNSNamespaces           []string
-	AllowedIssuerNamespaces        []string
-	CertificateApplyLimit          float64
-	CertificateApplyRetryBaseDelay time.Duration
-	CertificateApplyRetryMaxDelay  time.Duration
-	DefaultDNSTTL                  int32
-	DefaultDNSDelegationTTL        int32
+	ServiceKey                     client.ObjectKey `mapstructure:"-"`
+	DefaultDelegatedDomain         string           `mapstructure:"default-delegated-domain"`
+	DefaultIssuerKind              string           `mapstructure:"default-issuer-kind"`
+	DefaultIssuerName              string           `mapstructure:"default-issuer-name"`
+	IngressClassName               string           `mapstructure:"ingress-class-name"`
+	Prefix                         string           `mapstructure:"name-prefix"`
+	ServiceName                    string           `mapstructure:"service-name"`
+	AllowedDelegatedDomains        []string         `mapstructure:"allowed-delegated-domains"`
+	AllowedDNSNamespaces           []string         `mapstructure:"allowed-dns-namespaces"`
+	AllowedIssuerNamespaces        []string         `mapstructure:"allowed-issuer-namespaces"`
+	CRDs                           []string         `mapstructure:"crds"`
+	PropagatedAnnotations          []string         `mapstructure:"propagated-annotations"`
+	PropagatedLabels               []string         `mapstructure:"propagated-labels"`
+	CSRRevisionLimit               uint             `mapstructure:"csr-revision-limit"`
+	CertificateApplyLimit          float64          `mapstructure:"certificate-apply-limit"`
+	CertificateApplyRetryBaseDelay time.Duration    `mapstructure:"certificate-apply-retry-base-delay"`
+	CertificateApplyRetryMaxDelay  time.Duration    `mapstructure:"certificate-apply-retry-max-delay"`
+	AllowCustomDelegations         bool             `mapstructure:"allow-custom-delegations"`
+	CreateDNSEndpoint              bool             `mapstructure:"-"`
+	CreateCertificate              bool             `mapstructure:"-"`
+	DefaultDNSTTL                  int32            `mapstructure:"default-dns-ttl"`
+	DefaultDNSDelegationTTL        int32            `mapstructure:"default-dns-delegation-ttl"`
+}
+
+// BindFlags binds command line flags for ReconcilerOptions.
+func BindFlags(fs *pflag.FlagSet) {
+	fs.StringSlice("crds", []string{DNSEndpointKind, CertificateKind}, "List of CRD names to be created")
+	fs.String("name-prefix", "", "Prefix of CRD names to be created")
+	fs.String("service-name", "", "NamespacedName of the Contour LoadBalancer Service")
+	fs.String("default-issuer-name", "", "Issuer name used by default")
+	fs.String("default-issuer-kind", ClusterIssuerKind, "Issuer kind used by default")
+	fs.String("default-delegated-domain", "", "Delegated domain used by default")
+	fs.StringSlice("allowed-delegated-domains", []string{}, "List of allowed delegated domains")
+	fs.Bool("allow-custom-delegations", false, "Allow custom delegated domains via annotations")
+	fs.Uint("csr-revision-limit", 0, "Maximum number of CertificateRequest revisions to keep")
+	fs.String("ingress-class-name", "", "Ingress class name that watched by Contour Plus. If not specified, then all classes are watched")
+	fs.StringSlice("propagated-annotations", []string{}, "List of annotation keys to be propagated from HTTPProxy to generated resources")
+	fs.StringSlice("propagated-labels", []string{}, "List of label keys to be propagated from HTTPProxy to generated resources")
+	fs.StringSlice("allowed-dns-namespaces", []string{}, "List of namespaces where DNSEndpoint resources can be created. If empty, no namespaces are allowed")
+	fs.StringSlice("allowed-issuer-namespaces", []string{}, "List of namespaces where Certificate resources can be created. If empty, no namespaces are allowed")
+	fs.Float64("certificate-apply-limit", 0, "Maximum number of certificate apply operations allowed per second (0 disables rate limiting)")
+	fs.Duration("certificate-apply-retry-base-delay", DefaultRetryBaseDelay, "Base delay for certificate apply exponential backoff retry")
+	fs.Duration("certificate-apply-retry-max-delay", DefaultRetryMaxDelay, "Maximum delay for certificate apply exponential backoff retry")
+	fs.Int32("default-dns-ttl", DefaultDNSTTL, "Default TTL value for DNSEndpoint A records")
+	fs.Int32("default-dns-delegation-ttl", DefaultDNSDelegationTTL, "Default TTL value for DNSEndpoint CNAME delgation records")
+}
+
+// Finalize finalizes the ReconcilerOptions by setting derived fields.
+func (o *ReconcilerOptions) Finalize() error {
+	for _, crd := range o.CRDs {
+		switch crd {
+		case DNSEndpointKind:
+			o.CreateDNSEndpoint = true
+		case CertificateKind:
+			o.CreateCertificate = true
+		default:
+			return errors.New("unsupported CRD: " + crd)
+		}
+	}
+	nsName := strings.Split(o.ServiceName, "/")
+	if len(nsName) != 2 || nsName[0] == "" || nsName[1] == "" {
+		return errors.New("service-name should be valid string as namespaced-name")
+	}
+	o.ServiceKey = client.ObjectKey{
+		Namespace: nsName[0],
+		Name:      nsName[1],
+	}
+	return nil
+}
+
+// Validate validates the ReconcilerOptions.
+func (o *ReconcilerOptions) Validate() error {
+	if len(o.CRDs) == 0 {
+		return errors.New("at least one service need to be enabled")
+	}
+	switch o.DefaultIssuerKind {
+	case IssuerKind, ClusterIssuerKind:
+	default:
+		return errors.New("unsupported Issuer kind: " + o.DefaultIssuerKind)
+	}
+	if o.CertificateApplyLimit < 0 {
+		return errors.New("certificate-apply-limit must be greater than or equal to 0")
+	}
+	if o.CertificateApplyRetryBaseDelay <= 0 {
+		return errors.New("certificate-apply-retry-base-delay must be greater than 0")
+	}
+	if o.CertificateApplyRetryMaxDelay <= 0 {
+		return errors.New("certificate-apply-retry-max-delay must be greater than 0")
+	}
+	if o.CertificateApplyRetryMaxDelay < o.CertificateApplyRetryBaseDelay {
+		return errors.New("certificate-apply-retry-max-delay must be greater than or equal to certificate-apply-retry-base-delay")
+	}
+	if o.DefaultDNSTTL < 0 {
+		return errors.New("default-dns-ttl must be a positive integer")
+	}
+	if o.DefaultDNSDelegationTTL < 0 {
+		return errors.New("default-dns-delegation-ttl must be a positive integer")
+	}
+	return nil
 }
 
 // SetupScheme initializes a schema


### PR DESCRIPTION
Separate concerns by moving `ReconcilerOptions`-related flag definitions and related validations to the `controllers` package. This unclutters the `run()` function and drastically reduces the need to manually copy fields to `ReconcilerOptions` when instantiating it, which can be prone to error by omission when adding new fields.