### PR TITLE
Remove default linters from linters.enable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,11 @@
 version: "2"
 linters:
+  default: standard
   enable:
     - depguard
     - ginkgolinter
-    - govet
     - modernize
     - nilerr
-    - staticcheck
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
- Declare `linters.default` explicitly
- Remove `govet` and `staticcheck` as they belong to default linters

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
